### PR TITLE
Limit PHPUnit to version 5 (task #3311)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "cakephp/cakephp": ">3.0.0 <4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "^5.0",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "php": ">=5.4.16",
         "cakephp/cakephp": ">3.0.0 <4.0"
     },
     "require-dev": {


### PR DESCRIPTION
* Limit PHPUnit to version 5 to avoid PHP 5/7 incompatibilities introduced by PHPUnit 6.
* Removed PHP version check.