### PR TITLE
Moved csv migrations parsers (task #3309)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "require": {
         "cakephp/cakephp": ">3.0.0 <4.0",
         "maiconpinto/cakephp-adminlte-theme": "^1.0",
-        "burzum/cakephp-file-storage": "^1.1"
+        "burzum/cakephp-file-storage": "^1.1",
+        "league/csv": "^8.1",
+        "piwik/ini": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser;
+namespace Qobo\Utils\Parser;
 
 abstract class AbstractParser implements ParserInterface
 {

--- a/src/Parser/Csv/AbstractCsvParser.php
+++ b/src/Parser/Csv/AbstractCsvParser.php
@@ -1,8 +1,8 @@
 <?php
-namespace CsvMigrations\Parser\Csv;
+namespace Qobo\Utils\Parser\Csv;
 
-use CsvMigrations\Parser\AbstractParser;
 use League\Csv\Reader;
+use Qobo\Utils\Parser\AbstractParser;
 
 abstract class AbstractCsvParser extends AbstractParser
 {

--- a/src/Parser/Csv/ListParser.php
+++ b/src/Parser/Csv/ListParser.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser\Csv;
+namespace Qobo\Utils\Parser\Csv;
 
 /**
  * List CSV Parser

--- a/src/Parser/Csv/MigrationParser.php
+++ b/src/Parser/Csv/MigrationParser.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser\Csv;
+namespace Qobo\Utils\Parser\Csv;
 
 /**
  * Migration CSV Parser

--- a/src/Parser/Csv/Parser.php
+++ b/src/Parser/Csv/Parser.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser\Csv;
+namespace Qobo\Utils\Parser\Csv;
 
 use League\Csv\Reader;
 

--- a/src/Parser/Csv/ViewParser.php
+++ b/src/Parser/Csv/ViewParser.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser\Csv;
+namespace Qobo\Utils\Parser\Csv;
 
 use League\Csv\Reader;
 

--- a/src/Parser/Ini/AbstractIniParser.php
+++ b/src/Parser/Ini/AbstractIniParser.php
@@ -1,7 +1,7 @@
 <?php
-namespace CsvMigrations\Parser\Ini;
+namespace Qobo\Utils\Parser\Ini;
 
-use CsvMigrations\Parser\AbstractParser;
+use Qobo\Utils\Parser\AbstractParser;
 
 abstract class AbstractIniParser extends AbstractParser
 {

--- a/src/Parser/Ini/Parser.php
+++ b/src/Parser/Ini/Parser.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser\Ini;
+namespace Qobo\Utils\Parser\Ini;
 
 use Piwik\Ini\IniReader;
 

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace CsvMigrations\Parser;
+namespace Qobo\Utils\Parser;
 
 interface ParserInterface
 {

--- a/tests/TestCase/Parser/Csv/ListParserTest.php
+++ b/tests/TestCase/Parser/Csv/ListParserTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace CsvMigrations\Test\TestCase\Parser\Csv;
+namespace Qobo\Utils\Test\TestCase\Parser\Csv;
 
-use CsvMigrations\Parser\Csv\ListParser;
 use PHPUnit_Framework_TestCase;
+use Qobo\Utils\Parser\Csv\ListParser;
 
 class ListParserTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/TestCase/Parser/Csv/MigrationParserTest.php
+++ b/tests/TestCase/Parser/Csv/MigrationParserTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace CsvMigrations\Test\TestCase\Parser\Csv;
+namespace Qobo\Utils\Test\TestCase\Parser\Csv;
 
-use CsvMigrations\Parser\Csv\MigrationParser;
 use PHPUnit_Framework_TestCase;
+use Qobo\Utils\Parser\Csv\MigrationParser;
 
 class MigrationParserTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/TestCase/Parser/Csv/ParserTest.php
+++ b/tests/TestCase/Parser/Csv/ParserTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace CsvMigrations\Test\TestCase\Parser\Csv;
+namespace Qobo\Utils\Test\TestCase\Parser\Csv;
 
-use CsvMigrations\Parser\Csv\Parser;
 use PHPUnit_Framework_TestCase;
+use Qobo\Utils\Parser\Csv\Parser;
 
 class ParserTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/TestCase/Parser/Csv/ViewParserTest.php
+++ b/tests/TestCase/Parser/Csv/ViewParserTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace CsvMigrations\Test\TestCase\Parser\Csv;
+namespace Qobo\Utils\Test\TestCase\Parser\Csv;
 
-use CsvMigrations\Parser\Csv\ViewParser;
 use PHPUnit_Framework_TestCase;
+use Qobo\Utils\Parser\Csv\ViewParser;
 
 class ViewParserTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/TestCase/Parser/Ini/ParserTest.php
+++ b/tests/TestCase/Parser/Ini/ParserTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace CsvMigrations\Test\TestCase\Parser\Ini;
+namespace Qobo\Utils\Test\TestCase\Parser\Ini;
 
-use CsvMigrations\Parser\Ini\Parser;
 use PHPUnit_Framework_TestCase;
+use Qobo\Utils\Parser\Ini\Parser;
 
 class ParserTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/data/Modules/Common/lists/cities.csv
+++ b/tests/data/Modules/Common/lists/cities.csv
@@ -1,0 +1,4 @@
+VALUE,LABEL,INACTIVE
+limassol,Limassol,
+new_york,New York,
+london,London,

--- a/tests/data/Modules/Common/lists/countries.csv
+++ b/tests/data/Modules/Common/lists/countries.csv
@@ -1,0 +1,4 @@
+VALUE,LABEL,INACTIVE
+cy,Cyprus,
+usa,USA,
+uk,United Kingdom,

--- a/tests/data/Modules/Common/lists/currencies.csv
+++ b/tests/data/Modules/Common/lists/currencies.csv
@@ -1,0 +1,4 @@
+VALUE,LABEL,INACTIVE
+eur,EUR,
+usd,USD,
+gpb,GPB,

--- a/tests/data/Modules/Common/lists/foo_statuses.csv
+++ b/tests/data/Modules/Common/lists/foo_statuses.csv
@@ -1,0 +1,3 @@
+VALUE,LABEL,INACTIVE
+active,Active,
+inactive,Inactive,

--- a/tests/data/Modules/Common/lists/foo_types.csv
+++ b/tests/data/Modules/Common/lists/foo_types.csv
@@ -1,0 +1,4 @@
+VALUE,LABEL,INACTIVE
+bronze,Bronze,
+silver,Silver,
+gold,Gold,

--- a/tests/data/Modules/Common/lists/foo_types/bronze.csv
+++ b/tests/data/Modules/Common/lists/foo_types/bronze.csv
@@ -1,0 +1,3 @@
+VALUE,LABEL,INACTIVE
+new,New,
+used,Used,

--- a/tests/data/Modules/Common/lists/foo_types/gold.csv
+++ b/tests/data/Modules/Common/lists/foo_types/gold.csv
@@ -1,0 +1,3 @@
+VALUE,LABEL,INACTIVE
+new,New,
+used,Used,

--- a/tests/data/Modules/Common/lists/foo_types/silver.csv
+++ b/tests/data/Modules/Common/lists/foo_types/silver.csv
@@ -1,0 +1,3 @@
+VALUE,LABEL,INACTIVE
+new,New,
+used,Used,

--- a/tests/data/Modules/Common/lists/genders.csv
+++ b/tests/data/Modules/Common/lists/genders.csv
@@ -1,0 +1,3 @@
+VALUE,LABEL,INACTIVE
+m,Male,
+f,Female,

--- a/tests/data/Modules/Common/lists/units_area.csv
+++ b/tests/data/Modules/Common/lists/units_area.csv
@@ -1,0 +1,3 @@
+VALUE,LABEL,INACTIVE
+m,m&sup2;,
+ft,ft&sup2;,

--- a/tests/data/Modules/Foo/config/array_in_config.ini
+++ b/tests/data/Modules/Foo/config/array_in_config.ini
@@ -1,0 +1,11 @@
+[table]
+alias = Foobar
+searchable = true
+display_field = name
+
+[associations]
+; Associations might be generated based
+; on registryAlias, that's not really
+; readable.
+association_labels[] = BarIdBaz,'Baz'
+association_labels[] = FieldIdTableName,'Table Name'

--- a/tests/data/Modules/Foo/config/config.ini
+++ b/tests/data/Modules/Foo/config/config.ini
@@ -1,0 +1,20 @@
+[table]
+alias = Foobar
+searchable = true
+display_field = name
+typeahead_fields = name,foobar
+lookup_fields = foo,bar,baz
+
+[virtualFields]
+name = full_name
+
+[parent]
+module = TestModule
+redirect = self
+
+[associations]
+hide_associations = TestTable
+
+[associationLabels]
+FieldIdTable = Table
+AnotherIdTableTwo = "Pretty Table"

--- a/tests/data/Modules/Foo/config/other_config.ini
+++ b/tests/data/Modules/Foo/config/other_config.ini
@@ -1,0 +1,2 @@
+[other]
+config = true

--- a/tests/data/Modules/Foo/config/reports.ini
+++ b/tests/data/Modules/Foo/config/reports.ini
@@ -1,0 +1,7 @@
+[by_campaign_name]
+id = "cda938ac-951b-11e6-90a8-02a5372206b6"
+widget_type = "report"
+name = "Foo By name"
+query = "SELECT * From foobar LIMIT 1"
+columns = id,name
+renderAs = table

--- a/tests/data/Modules/Foo/db/migration.csv
+++ b/tests/data/Modules/Foo/db/migration.csv
@@ -1,0 +1,18 @@
+FIELD NAME,FIELD TYPE,REQUIRED,NOT SEARCHABLE,UNIQUE
+id,uuid
+description,text,,1
+name,string,1,,1
+status,list(foo_statuses),1
+type,list(foo_types),1
+gender,list(genders)
+city,list(cities)
+country,list(countries)
+cost,money(currencies)
+birthdate,date
+reminder_date,reminder
+created,datetime
+modified,datetime
+garden_area,metric(units_area)
+is_primary,boolean
+start_time,time
+balance,decimal(12.4)

--- a/tests/data/Modules/Foo/views/add.csv
+++ b/tests/data/Modules/Foo/views/add.csv
@@ -1,0 +1,6 @@
+PANEL NAME,FIRST COLUMN FIELD NAME,SECOND COLUMN FIELD NAME
+Details,status,type
+Details,name,description
+Details,cost,
+Personal,gender,birthdate,
+Personal,city,country

--- a/tests/data/Modules/Foo/views/edit.csv
+++ b/tests/data/Modules/Foo/views/edit.csv
@@ -1,0 +1,6 @@
+PANEL NAME,FIRST COLUMN FIELD NAME,SECOND COLUMN FIELD NAME
+Details,status,type
+Details,name,description
+Details,cost,
+Personal,gender,birthdate,
+Personal,city,country

--- a/tests/data/Modules/Foo/views/index.csv
+++ b/tests/data/Modules/Foo/views/index.csv
@@ -1,0 +1,7 @@
+FIELD NAME
+status
+type
+name
+cost
+created
+modified

--- a/tests/data/Modules/Foo/views/view.csv
+++ b/tests/data/Modules/Foo/views/view.csv
@@ -1,0 +1,7 @@
+PANEL NAME,FIRST COLUMN FIELD NAME,SECOND COLUMN FIELD NAME
+Details,status,type
+Details,name,description
+Details,cost,
+Details,created,modified
+Personal,gender,birthdate,
+Personal,city,country


### PR DESCRIPTION
Moved CSV Migrations plugin ([link](https://github.com/QoboLtd/cakephp-csv-migrations)) parsers to this plugin, as they are commonly used throughout our plugins. Parsers included are `CSV` and `INI`.