### PR TITLE
Adding getters for Models and its columns

### DIFF
--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -52,4 +52,17 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(in_array('Blah.UsersController', $result), "Test app UsersController is not in the list (plugin=Blah,fqcn=false)");
         $this->assertFalse(in_array('Blah.AppController', $result), "Test app AppController is in the list (plugin=Blah,fqcn=false)");
     }
+
+    public function testGetModels()
+    {
+        $result = Utility::getModels('test');
+        $this->assertTrue(is_array($result));
+    }
+
+    public function testGetModelColumns()
+    {
+        $result = Utility::getModelColumns('Users', 'test');
+
+        $this->assertTrue(is_array($result));
+    }
 }


### PR DESCRIPTION
Few useful methods added:
-  Get the list of all current models based on ConnectionManager. (with or without phinxlog tables).
- Get the list of model columns based on ConnectionManager.
