### PR TITLE
Added burzum/cakephp-imagine-plugin to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "cakephp/migrations": "~1.0",
         "maiconpinto/cakephp-adminlte-theme": "^1.0",
         "burzum/cakephp-file-storage": "^1.2",
+        "burzum/cakephp-imagine-plugin": "^2.1",
         "muffin/trash": "^1.1",
         "league/csv": "^8.1",
         "league/json-guard": "^0.5",


### PR DESCRIPTION
Since we already use burzum/cakephp-file-storage, it makes sense
to keep them together, as they interoperate very frequently.  Having
one without another, and loading imagine plugin separately on the
application level or in another plugin seems confusion and
non-obvious.