### PR TITLE
Lock CakePHP to 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "cakephp/cakephp": "^3.4",
+        "cakephp/cakephp": "^3.4.0 <3.5.0",
         "cakephp/migrations": "~1.0",
         "maiconpinto/cakephp-adminlte-theme": "^1.0",
         "burzum/cakephp-file-storage": "^1.2",


### PR DESCRIPTION
There are some behavioral changes in CakePHP 3.5 so we'll need
to update separately.

https://book.cakephp.org/3.0/en/appendices/3-5-migration-guide.html

For now, sticking to 3.4.