### PR TITLE
Replacing alerts with silent console messages (task #5024)

### DIFF
--- a/webroot/js/dataTables.init.js
+++ b/webroot/js/dataTables.init.js
@@ -91,7 +91,7 @@ DataTablesInit.prototype = {
         }
 
         // Fetching alerted errors into callback
-        $.fn.dataTable.ext.errMode = function(settings, techNote, message) {
+        $.fn.dataTable.ext.errMode = function (settings, techNote, message) {
             console.log(message);
         };
 

--- a/webroot/js/dataTables.init.js
+++ b/webroot/js/dataTables.init.js
@@ -90,6 +90,11 @@ DataTablesInit.prototype = {
             settings.stateDuration = this.options.state.duration;
         }
 
+        // Fetching alerted errors into callback
+        $.fn.dataTable.ext.errMode = function(settings, techNote, message) {
+            console.log(message);
+        };
+
         var table = $(this.options.table_id).DataTable(settings);
 
         return table;


### PR DESCRIPTION
Until now, we silently report error in the browser console.
Once the things get more stable client-side, we'd replace
it with thowable behavior.

Reference: https://datatables.net/reference/event/error