### PR TITLE
Lock CakePHP to v3.5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "burzum/cakephp-file-storage": "^1.2",
         "burzum/cakephp-imagine-plugin": "^2.1",
         "cakedc/users": "^4.0",
-        "cakephp/cakephp": "^3.5.0",
+        "cakephp/cakephp": "3.5.8",
         "cakephp/migrations": "~1.0",
         "doctrine/annotations": "v1.4.0",
         "doctrine/instantiator": "1.0.5",


### PR DESCRIPTION
Locking CakePHP to v3.5.8 because of this [issue](https://github.com/cakephp/cakephp/issues/11577) caused by CakePHP v3.5.9 release. The [fix](https://github.com/cakephp/cakephp/pull/11578) has been merged and set for the next patch release, v3.5.10.