### PR TITLE
Revert "Lock CakePHP to v3.5.8"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "burzum/cakephp-file-storage": "^1.2",
         "burzum/cakephp-imagine-plugin": "^2.1",
         "cakedc/users": "^4.0",
-        "cakephp/cakephp": "3.5.8",
+        "cakephp/cakephp": "^3.5.0",
         "cakephp/migrations": "~1.0",
         "doctrine/annotations": "v1.4.0",
         "doctrine/instantiator": "1.0.5",


### PR DESCRIPTION
This reverts commit c5ea769bf6b0efba832859207b7579b366383183.