### PR TITLE
Relaxed validation for default value of the field (task #5293)

### DIFF
--- a/src/ModuleConfig/Parser/Schema/fields.json
+++ b/src/ModuleConfig/Parser/Schema/fields.json
@@ -15,7 +15,12 @@
                 "default": {
                     "title": "Default value",
                     "description": "Default value for the field",
-                    "type": "string"
+                    "anyOf": [
+                        { "type": "boolean" },
+                        { "type": "integer" },
+                        { "type": "number" },
+                        { "type": "string" }
+                    ]
                 },
                 "renderAs": {
                     "title": "Render value",


### PR DESCRIPTION
Default values can vary depending on the field type - strings,
integers, floats, boolean, etc.