### PR TITLE
Minor refactoring (task #5473)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,6 +4,8 @@ use Burzum\FileStorage\Storage\StorageManager;
 use Burzum\FileStorage\Storage\StorageUtils;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
+use Exception;
+use Qobo\Utils\Utility;
 
 /**
  * Burzum File-Storage configuration
@@ -81,30 +83,24 @@ StorageManager::config('Local', [
 EventManager::instance()->on(new BaseListener(Configure::read('FileStorage')));
 
 /**
- * Convert size to bytes.
+ * Convert size value to bytes
  *
- * Convert sizes from php settings like post_max_size
- * for example 8M to integer number of bytes.
+ * NOTE: This is left here purely for backward-compatibility reasons.
  *
- * If number is integer return as is.
- *
+ * @obsolete
  * @param string|int $size Size to convert
  * @return int
  */
 function sizeToBytes($size)
 {
-    if (is_int($size)) {
-        return $size;
+    try {
+        $result = Utility::valueToBytes($size);
+    } catch (Exception $e) {
+        // Mimic initial behavior, before exception was introduced
+        $result = (string)$size;
+        $result = (int)$result;
+        return $result;;
     }
 
-    $result = (string)$size;
-    if (preg_match('/(\d+)K/i', $result, $matches)) {
-        $result = $matches[1] * 1024;
-    } elseif (preg_match('/(\d+)M/i', $result, $matches)) {
-        $result = $matches[1] * 1024 * 1024;
-    } elseif (preg_match('/(\d+)G/i', $result, $matches)) {
-        $result = $matches[1] * 1024 * 1024 * 1024;
-    }
-
-    return (int)$result;
+    return $result;
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -316,9 +316,7 @@ class Utility
     {
         $result = [];
 
-        if (empty($config)) {
-            $config = Configure::read('Colors');
-        }
+        $config = empty($config) ? Configure::read('Colors') : $config;
 
         if (!$pretty) {
             return $config;
@@ -349,9 +347,7 @@ class Utility
         ];
 
         // passing default icons if no external config present.
-        if (empty($config)) {
-            $config = Configure::read('Icons');
-        }
+        $config = empty($config) ? Configure::read('Icons') : $config;
 
         if (empty($config)) {
             return $result;

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -149,7 +149,9 @@ class Utility
             ];
         }
 
-        $apis = self::sortApiVersions($apis);
+        if (!empty($apis)) {
+            $apis = self::sortApiVersions($apis);
+        }
 
         return $apis;
     }
@@ -408,10 +410,6 @@ class Utility
      */
     protected static function sortApiVersions(array $versions = [])
     {
-        if (empty($versions)) {
-            return $versions;
-        }
-
         usort($versions, function ($first, $second) {
             $firstVersion = (float)$first['number'];
             $secondVersion = (float)$second['number'];

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -24,6 +24,52 @@ use InvalidArgumentException;
 class Utility
 {
     /**
+     * Convert value to bytes
+     *
+     * Convert sizes from PHP settings like post_max_size
+     * for example 8M to integer number of bytes.
+     *
+     * If number is integer return as is.
+     *
+     * NOTE: This is a modified copy from qobo/cakephp-utils/config/bootstrap.php
+     *
+     * @throws \InvalidArgumentException when cannot convert
+     * @param string|int $value Value to convert
+     * @return int
+     */
+    public static function valueToBytes($value)
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        $value = (string)$value;
+        $value = trim($value);
+
+        // Bytes
+        if (preg_match('/^(\d+)$/', $value, $matches)) {
+            return (int)$matches[1];
+        }
+
+        // Kilobytes
+        if (preg_match('/(\d+)K$/i', $value, $matches)) {
+            return (int)($matches[1] * 1024);
+        }
+
+        // Megabytes
+        if (preg_match('/(\d+)M$/i', $value, $matches)) {
+            return (int)($matches[1] * 1024 * 1024);
+        }
+
+        // Gigabytes
+        if (preg_match('/(\d+)G$/i', $value, $matches)) {
+            return (int)($matches[1] * 1024 * 1024 * 1024);
+        }
+
+        throw new InvalidArgumentException("Failed to find K, M, or G in a non-integer value [$value]");
+    }
+
+    /**
      * Check validity of the given path
      *
      * @throws \InvalidArgumentException when path does not exist or is not readable

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -8,6 +8,37 @@ use Qobo\Utils\Utility;
 
 class UtilityTest extends TestCase
 {
+    public function valueBytesProvider()
+    {
+        return [
+            [42, 42, 'Integer value'],
+            ['42', 42, 'Integer as string'],
+            ['42k', 43008, 'Lowercase kilobytes'],
+            ['42K', 43008, 'Uppercase kilobytes'],
+            ['42m', 44040192, 'Lowercase megabytes'],
+            ['42M', 44040192, 'Uppercase megabytes'],
+            ['42g', 45097156608, 'Lowercase gigabytes'],
+            ['42G', 45097156608, 'Uppercase gigabytes'],
+        ];
+    }
+
+    /**
+     * @dataProvider valueBytesProvider
+     */
+    public function testValueToBytes($value, $expected, $description)
+    {
+        $result = Utility::valueToBytes($value);
+        $this->assertEquals($expected, $result, "valueToBytes() failed for: $description");
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testValueToBytesException()
+    {
+        $result = Utility::valueToBytes('this is not a byte size value');
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
* Moved global function `sizeToBytes()` from `config/bootstrap.php` to the `Utility::valueToBytes()`, leaving a backward-compatibility placeholder.
* Minor code changes for improved test coverage.