### PR TITLE
Minor fix

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,7 +4,6 @@ use Burzum\FileStorage\Storage\StorageManager;
 use Burzum\FileStorage\Storage\StorageUtils;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
-use Exception;
 use Qobo\Utils\Utility;
 
 /**


### PR DESCRIPTION
PHP files in `config/` folder do not define any namespace, so they
remain in the global one.  Adding `use` statements for any global
classes, like PHP built-in exceptions, results in the following
PHP warning:

```
Warning Error: The use statement with non-compound name 'Exception'
has no effect in [config/bootstrap.php, line 7]
```

This commit removes the `use Exception;` statement from the
`bootstrap.php` file, that triggered the above warning.