### PR TITLE
Support negative values in valueToBytes()

### DIFF
--- a/src/Utility.php
+++ b/src/Utility.php
@@ -46,24 +46,31 @@ class Utility
         $value = (string)$value;
         $value = trim($value);
 
+        // Native PHP check for digits in string
+        if(ctype_digit(ltrim((string)$value, '-'))){
+            return (int)$value;
+        }
+
+        $signed = (substr($value, 0, 1) === '-') ? -1 : 1;
+
         // Bytes
         if (preg_match('/^(\d+)$/', $value, $matches)) {
-            return (int)$matches[1];
+            return (int)$matches[1] * $signed;
         }
 
         // Kilobytes
         if (preg_match('/(\d+)K$/i', $value, $matches)) {
-            return (int)($matches[1] * 1024);
+            return (int)($matches[1] * $signed * 1024);
         }
 
         // Megabytes
         if (preg_match('/(\d+)M$/i', $value, $matches)) {
-            return (int)($matches[1] * 1024 * 1024);
+            return (int)($matches[1] * $signed * 1024 * 1024);
         }
 
         // Gigabytes
         if (preg_match('/(\d+)G$/i', $value, $matches)) {
-            return (int)($matches[1] * 1024 * 1024 * 1024);
+            return (int)($matches[1] * $signed * 1024 * 1024 * 1024);
         }
 
         throw new InvalidArgumentException("Failed to find K, M, or G in a non-integer value [$value]");

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -47,7 +47,7 @@ class Utility
         $value = trim($value);
 
         // Native PHP check for digits in string
-        if(ctype_digit(ltrim((string)$value, '-'))){
+        if (ctype_digit(ltrim((string)$value, '-'))) {
             return (int)$value;
         }
 

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -11,14 +11,29 @@ class UtilityTest extends TestCase
     public function valueBytesProvider()
     {
         return [
-            [42, 42, 'Integer value'],
-            ['42', 42, 'Integer as string'],
-            ['42k', 43008, 'Lowercase kilobytes'],
-            ['42K', 43008, 'Uppercase kilobytes'],
-            ['42m', 44040192, 'Lowercase megabytes'],
-            ['42M', 44040192, 'Uppercase megabytes'],
-            ['42g', 45097156608, 'Lowercase gigabytes'],
-            ['42G', 45097156608, 'Uppercase gigabytes'],
+            [-42, -42, 'Negative integer value'],
+            [42, 42, 'Positive integer value'],
+
+            ['-42', -42, 'Negative integer as string'],
+            ['42', 42, 'Positive integer as string'],
+
+            ['-42k', -43008, 'Negative lowercase kilobytes'],
+            ['42k', 43008, 'Positive lowercase kilobytes'],
+
+            ['-42K', -43008, 'Negative uppercase kilobytes'],
+            ['42K', 43008, 'Positive uppercase kilobytes'],
+
+            ['-42m', -44040192, 'Negative lowercase megabytes'],
+            ['42m', 44040192, 'Positive lowercase megabytes'],
+
+            ['-42M', -44040192, 'Negative uppercase megabytes'],
+            ['42M', 44040192, 'Positive uppercase megabytes'],
+
+            ['-42g', -45097156608, 'Negative lowercase gigabytes'],
+            ['42g', 45097156608, 'Positive lowercase gigabytes'],
+
+            ['-42G', -45097156608, 'Negative uppercase gigabytes'],
+            ['42G', 45097156608, 'Positive uppercase gigabytes'],
         ];
     }
 


### PR DESCRIPTION
Converting value to bytes now supports negative values as well,
which is specifically handy for cases like PHP's `memory_limit=-1`.