### PR TITLE
Lock CakePHP to v3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "burzum/cakephp-file-storage": "^1.2",
         "burzum/cakephp-imagine-plugin": "^2.1",
         "cakedc/users": "^4.0",
-        "cakephp/cakephp": "^3.5.0",
+        "cakephp/cakephp": "~3.5.0",
         "cakephp/migrations": "~1.0",
         "friendsofcake/crud": "^4.3",
         "fzaninotto/faker": "^1.0",


### PR DESCRIPTION
Changelogs summary:

 - cakephp/cakephp downgraded from 3.6.1 to 3.5.15
   See changes: https://github.com/cakephp/cakephp/compare/3.6.1...3.5.15
   Release notes: https://github.com/cakephp/cakephp/releases/tag/3.5.15

 - cakephp/migrations downgraded from 1.8.1 to 1.7.2
   See changes: https://github.com/cakephp/migrations/compare/1.8.1...1.7.2
   Release notes: https://github.com/cakephp/migrations/releases/tag/1.7.2