### PR TITLE
Removed dependency on piwik/ini

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "maiconpinto/cakephp-adminlte-theme": "^1.0",
         "muffin/trash": "^1.1",
         "myclabs/php-enum": "^1.5",
-        "piwik/ini": "^1.0",
         "pyrech/composer-changelogs": "^1.4",
         "riesenia/cakephp-duplicatable": "^3.0",
         "rlanvin/php-rrule": "^1.6"

--- a/src/ModuleConfig/Parser/V1/Ini/AbstractIniParser.php
+++ b/src/ModuleConfig/Parser/V1/Ini/AbstractIniParser.php
@@ -13,7 +13,6 @@ namespace Qobo\Utils\ModuleConfig\Parser\V1\Ini;
 
 use Exception;
 use InvalidArgumentException;
-use Piwik\Ini\IniReader;
 use Qobo\Utils\ModuleConfig\Parser\AbstractParser;
 use Qobo\Utils\Utility;
 
@@ -29,8 +28,8 @@ abstract class AbstractIniParser extends AbstractParser
     protected function getDataFromRealPath($path)
     {
         try {
-            $reader = new IniReader();
-            $data = $reader->readFile($path);
+            $data = parse_ini_file($path, true, INI_SCANNER_TYPED);
+            $data = json_decode(json_encode($data), false);
         } catch (Exception $e) {
             throw new InvalidArgumentException("Failed to read path: $path");
         }


### PR DESCRIPTION
Reasons, in no particular order:

* piwik/ini is a GPL-based library.  We prefer MIT.
* piwik/ini is obsolete/abandoned.
* INI file parsing is now kept for backward-compatibility only.
* PHP provides a native INI parser, which is sufficient for BC.
* One less composer dependency to download.