### PR TITLE
Module lists fallback (task #5596)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "arvenil/ninja-mutex": "^0.6",
         "burzum/cakephp-file-storage": "^1.2",
         "burzum/cakephp-imagine-plugin": "^2.1",
-        "cakedc/users": "^6.0",
+        "cakedc/users": "^4.0",
         "cakephp/cakephp": "~3.5.0",
         "cakephp/migrations": "~1.0",
         "friendsofcake/crud": "^5.4",

--- a/src/ModuleConfig/PathFinder/V2/ListPathFinder.php
+++ b/src/ModuleConfig/PathFinder/V2/ListPathFinder.php
@@ -72,7 +72,7 @@ class ListPathFinder extends BasePathFinder
 
         $result = null;
         try {
-            $result = parent::find($module, $path, $validate);
+            $result = parent::find($module, $path, true);
         } catch (\Exception $e) {
             if ($module == self::DEFAULT_MODULE) {
                 $this->fail($e);
@@ -81,7 +81,7 @@ class ListPathFinder extends BasePathFinder
 
         if (($result === null) && ($module <> self::DEFAULT_MODULE)) {
             $this->warnings[] = "Module list not found.  Falling back on module " . self::DEFAULT_MODULE;
-            $result = parent::find(self::DEFAULT_MODULE, $path, $validate);
+            $result = parent::find(self::DEFAULT_MODULE, $path, true);
         }
 
         return $result;

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
@@ -27,7 +27,7 @@ class ListParserTest extends PHPUnit_Framework_TestCase
 
     public function testParse()
     {
-        $file = $this->dataDir . DS . 'Foo'. DS . 'lists' . DS . 'local_genders.json';
+        $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file);
 
         $resultArray = json_decode(json_encode($result), true);
@@ -39,17 +39,16 @@ class ListParserTest extends PHPUnit_Framework_TestCase
 
     public function testFilter()
     {
-        $file = $this->dataDir . DS . 'Foo'. DS . 'lists' . DS . 'local_genders.json';
+        $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file, ['filter' => true]);
 
         $resultArray = json_decode(json_encode($result), true);
         $this->assertTrue(!in_array('foo', array_keys($resultArray['items'])));
     }
 
-
     public function testFlatten()
     {
-        $file = $this->dataDir . DS . 'Foo'. DS . 'lists' . DS . 'local_genders.json';
+        $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file, ['filter' => true, 'flatten' => true]);
 
         $resultArray = json_decode(json_encode($result), true);

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V2\Json;
+
+use Cake\Core\Configure;
+use PHPUnit_Framework_TestCase;
+use Qobo\Utils\ModuleConfig\Parser\V2\Json\ListParser;
+
+class ListParserTest extends PHPUnit_Framework_TestCase
+{
+    protected $parser;
+    protected $dataDir;
+
+    public function setUp()
+    {
+        $this->parser = new ListParser();
+        $this->dataDir = TESTS . 'data' . DS . 'Modules';
+
+        Configure::write('CsvMigrations.modules.path', $this->dataDir);
+        Configure::write('ModuleConfig.classMapVersion', 'V2');
+    }
+
+    public function tearDown()
+    {
+        unset($this->parser);
+        unset($this->dataDir);
+    }
+
+    public function testParse()
+    {
+        $file = $this->dataDir . DS . 'Foo'. DS . 'lists' . DS . 'local_genders.json';
+        $result = $this->parser->parse($file);
+
+        $resultArray = json_decode(json_encode($result), true);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('items', $resultArray);
+        $this->assertEquals($resultArray['items']['m']['label'], 'M - Male');
+    }
+
+    public function testFilter()
+    {
+        $file = $this->dataDir . DS . 'Foo'. DS . 'lists' . DS . 'local_genders.json';
+        $result = $this->parser->parse($file, ['filter' => true]);
+
+        $resultArray = json_decode(json_encode($result), true);
+        $this->assertTrue(!in_array('foo', array_keys($resultArray['items'])));
+    }
+
+
+    public function testFlatten()
+    {
+        $file = $this->dataDir . DS . 'Foo'. DS . 'lists' . DS . 'local_genders.json';
+        $result = $this->parser->parse($file, ['filter' => true, 'flatten' => true]);
+
+        $resultArray = json_decode(json_encode($result), true);
+
+        $this->assertTrue(in_array('bar.bar_one', array_keys($resultArray['items'])));
+        $this->assertTrue(in_array('bar.bar_two', array_keys($resultArray['items'])));
+    }
+}

--- a/tests/data/Modules/Foo/lists/local_genders.json
+++ b/tests/data/Modules/Foo/lists/local_genders.json
@@ -1,0 +1,41 @@
+{
+    "items": [
+        {
+            "value": "m",
+            "label": "M - Male",
+            "inactive": "",
+            "children": []
+        },
+        {
+            "value": "f",
+            "label": "F - Female",
+            "inactive": "",
+            "children": []
+        },
+        {
+            "value": "foo",
+            "label": "Foo - inactive",
+            "inactive": "1",
+            "children": []
+        },
+        {
+            "value": "bar",
+            "label": "Bar - with children",
+            "inactive": "",
+            "children": [
+                {
+                    "value": "bar_one",
+                    "label": "bar One",
+                    "inactive": "",
+                    "children": []
+                },
+                {
+                    "value": "bar_two",
+                    "label": "bar Two",
+                    "inactive": "",
+                    "children": []
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Whenever we use a CSV module from `qobo/cakephp-csv-migrations` we want the system to look for the lists inside the module `lists/` directory.

If nothing was found - to fallback to `modules/Common/lists` directory.