### PR TITLE
Switch from PHP 5.6 to PHP 7.1 (task #7636)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - nightly
@@ -24,7 +22,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.2
     - php: nightly
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
   - vendor/bin/phpcs
+  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "5.6"
+            "php": "7.1"
         }
     },
     "require": {
@@ -40,7 +40,7 @@
         "rlanvin/php-rrule": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^6.0",
         "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,7 +24,7 @@
 		<log type="coverage-html" target="build/coverage"/>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
 		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+		<log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
     <!-- Setup a listener for fixtures -->

--- a/tests/TestCase/ModuleConfig/Parser/Schema/SchemaTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/Schema/SchemaTest.php
@@ -3,9 +3,9 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\Schema;
 
 use Cake\Core\Configure;
 use DirectoryIterator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SchemaTest extends PHPUnit_Framework_TestCase
+class SchemaTest extends TestCase
 {
     /**
      * Lint JSON files

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/ListParserTest.php
@@ -3,10 +3,10 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Csv;
 
 use Cake\Core\Configure;
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\ListParser;
 
-class ListParserTest extends PHPUnit_Framework_TestCase
+class ListParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/MigrationParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/MigrationParserTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Csv;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\MigrationParser;
 
-class MigrationParserTest extends PHPUnit_Framework_TestCase
+class MigrationParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/ViewParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/ViewParserTest.php
@@ -3,10 +3,10 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Csv;
 
 use Cake\Core\Configure;
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\ViewParser;
 
-class ViewParserTest extends PHPUnit_Framework_TestCase
+class ViewParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/ConfigParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/ConfigParserTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Ini;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\ConfigParser;
 
-class ConfigParserTest extends PHPUnit_Framework_TestCase
+class ConfigParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/FieldsParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/FieldsParserTest.php
@@ -3,10 +3,10 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Ini;
 
 use Cake\Core\Configure;
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\FieldsParser;
 
-class FieldsParserTest extends PHPUnit_Framework_TestCase
+class FieldsParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/ReportsParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/ReportsParserTest.php
@@ -3,10 +3,10 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Ini;
 
 use Cake\Core\Configure;
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\ReportsParser;
 
-class ReportsParserTest extends PHPUnit_Framework_TestCase
+class ReportsParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V1/Json/MenusParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Json/MenusParserTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Json;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Json\MenusParser;
 
-class MenusParserTest extends PHPUnit_Framework_TestCase
+class MenusParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V2\Json;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V2\Json\ListParser;
 
-class ListParserTest extends PHPUnit_Framework_TestCase
+class ListParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ViewParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ViewParserTest.php
@@ -3,10 +3,10 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V2\Json;
 
 use Cake\Core\Configure;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V2\Json\ViewParser;
 
-class ViewParserTest extends PHPUnit_Framework_TestCase
+class ViewParserTest extends TestCase
 {
     protected $parser;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/PathFinder/V1/ConfigPathFinderTest.php
+++ b/tests/TestCase/ModuleConfig/PathFinder/V1/ConfigPathFinderTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\PathFinder\V1;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\PathFinder\V1\ConfigPathFinder;
 
-class ConfigPathFinderTest extends PHPUnit_Framework_TestCase
+class ConfigPathFinderTest extends TestCase
 {
     protected $pf;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/PathFinder/V1/FieldsPathFinderTest.php
+++ b/tests/TestCase/ModuleConfig/PathFinder/V1/FieldsPathFinderTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\PathFinder\V1;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\PathFinder\V1\FieldsPathFinder;
 
-class FieldsPathFinderTest extends PHPUnit_Framework_TestCase
+class FieldsPathFinderTest extends TestCase
 {
     protected $pf;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/PathFinder/V1/ListPathFinderTest.php
+++ b/tests/TestCase/ModuleConfig/PathFinder/V1/ListPathFinderTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\PathFinder\V1;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\PathFinder\V1\ListPathFinder;
 
-class ListPathFinderTest extends PHPUnit_Framework_TestCase
+class ListPathFinderTest extends TestCase
 {
     protected $pf;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/PathFinder/V1/MigrationPathFinderTest.php
+++ b/tests/TestCase/ModuleConfig/PathFinder/V1/MigrationPathFinderTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\PathFinder\V1;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\PathFinder\V1\MigrationPathFinder;
 
-class MigrationPathFinderTest extends PHPUnit_Framework_TestCase
+class MigrationPathFinderTest extends TestCase
 {
     protected $pf;
     protected $dataDir;

--- a/tests/TestCase/ModuleConfig/PathFinder/V1/ViewPathFinderTest.php
+++ b/tests/TestCase/ModuleConfig/PathFinder/V1/ViewPathFinderTest.php
@@ -2,10 +2,10 @@
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\PathFinder\V1;
 
 use Cake\Core\Configure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\PathFinder\V1\ViewPathFinder;
 
-class ViewPathFinderTest extends PHPUnit_Framework_TestCase
+class ViewPathFinderTest extends TestCase
 {
     protected $pf;
     protected $dataDir;

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -3,7 +3,6 @@ namespace Qobo\Utils\Test\TestCase;
 
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
 use Qobo\Utils\Utility;
 
 class UtilityTest extends TestCase


### PR DESCRIPTION
This release drops support for PHP 5.6.  The minimum required version is now PHP 7.1