### PR TITLE
objecttoArray() helper (task #7090)

### DIFF
--- a/src/ModuleConfig/ModuleConfig.php
+++ b/src/ModuleConfig/ModuleConfig.php
@@ -161,7 +161,8 @@ class ModuleConfig implements ErrorAwareInterface
      */
     public function parse()
     {
-        $cache = $parser = $exception = $cacheKey = $result = $path = null;
+        $result = new stdClass();
+        $cache = $parser = $exception = $cacheKey = $path = null;
         try {
             $path = $this->find(false);
             // Cached response
@@ -243,7 +244,7 @@ class ModuleConfig implements ErrorAwareInterface
      * @param string $caller Caller that generated a message
      * @return void
      */
-    protected function mergeMessages($source, string $caller = 'ModuleConfig'): void
+    protected function mergeMessages($source = null, string $caller = 'ModuleConfig'): void
     {
         $source = is_object($source) ? $source : new stdClass();
 

--- a/src/ModuleConfig/ModuleConfig.php
+++ b/src/ModuleConfig/ModuleConfig.php
@@ -16,6 +16,7 @@ use Qobo\Utils\ErrorAwareInterface;
 use Qobo\Utils\ErrorTrait;
 use Qobo\Utils\ModuleConfig\Cache\Cache;
 use Qobo\Utils\ModuleConfig\Cache\PathCache;
+use Qobo\Utils\Utility;
 use stdClass;
 
 /**
@@ -189,6 +190,19 @@ class ModuleConfig implements ErrorAwareInterface
         if ($cache && $cacheKey) {
             $cache->writeTo($cacheKey, $result, ['path' => $path]);
         }
+
+        return $result;
+    }
+
+    /**
+     * Parse module configuration file to associative array
+     *
+     * @return mixed[] Whatever Parser returned, converted to array
+     */
+    public function parseToArray(): array
+    {
+        $result = $this->parse();
+        $result = Utility::objectToArray($result);
 
         return $result;
     }

--- a/src/ModuleConfig/Parser/V1/Ini/ConfigParser.php
+++ b/src/ModuleConfig/Parser/V1/Ini/ConfigParser.php
@@ -11,6 +11,7 @@
  */
 namespace Qobo\Utils\ModuleConfig\Parser\V1\Ini;
 
+use Qobo\Utils\Utility;
 use stdClass;
 
 /**
@@ -97,7 +98,7 @@ class ConfigParser extends AbstractIniParser
         $data->notifications->ignored_fields = $this->csv2array($data->notifications->ignored_fields);
         $data->manyToMany->modules = $this->csv2array($data->manyToMany->modules);
 
-        $virtualFields = json_decode(json_encode($data->virtualFields), true);
+        $virtualFields = Utility::objectToArray($data->virtualFields);
         foreach ($virtualFields as $virtualField => $realFields) {
             $data->virtualFields->$virtualField = $this->csv2array($realFields);
         }

--- a/src/ModuleConfig/Parser/V2/Json/ListParser.php
+++ b/src/ModuleConfig/Parser/V2/Json/ListParser.php
@@ -11,6 +11,8 @@
  */
 namespace Qobo\Utils\ModuleConfig\Parser\V2\Json;
 
+use Qobo\Utils\Utility;
+
 /**
  * List JSON Parser
  *
@@ -50,7 +52,7 @@ class ListParser extends AbstractJsonParser
         $options = array_merge($this->options, $options);
 
         $result = parent::parse($path, $options);
-        $data = json_decode(json_encode($result), true);
+        $data = Utility::objectToArray($result);
         $result->items = $this->normalize($data['items']);
 
         if ($options['filter']) {

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -533,4 +533,36 @@ class Utility
 
         return $clientCountryCode;
     }
+
+    /**
+     * Convert an object to associative array
+     *
+     * NOTE: in case of any issues during the conversion, this
+     * method will return an empty array and NOT throw any
+     * exceptions.
+     *
+     * @param object $source Object to convert
+     * @return mixed[]
+     */
+    public static function objectToArray($source): array
+    {
+        $result = [];
+
+        if (!is_object($source)) {
+            return $result;
+        }
+
+        $json = json_encode($source);
+        if ($json === false) {
+            return $result;
+        }
+
+        $array = json_decode($json, true);
+        if ($array === null) {
+            return $result;
+        }
+        $result = $array;
+
+        return $result;
+    }
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -541,12 +541,16 @@ class Utility
      * method will return an empty array and NOT throw any
      * exceptions.
      *
-     * @param object $source Object to convert
+     * @param mixed $source Object to convert
      * @return mixed[]
      */
     public static function objectToArray($source): array
     {
         $result = [];
+
+        if (is_array($source)) {
+            return $source;
+        }
 
         if (!is_object($source)) {
             return $result;

--- a/tests/TestCase/ModuleConfig/ModuleConfigTest.php
+++ b/tests/TestCase/ModuleConfig/ModuleConfigTest.php
@@ -6,6 +6,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
+use Qobo\Utils\Utility;
 
 class ModuleConfigTest extends TestCase
 {
@@ -105,7 +106,8 @@ class ModuleConfigTest extends TestCase
             $this->fail($e->getMessage());
         }
         $this->assertTrue(is_object($result), "Result is not an object");
-        $this->assertFalse(empty(json_decode(json_encode($result), true)), "Result is empty");
+        $result = Utility::objectToArray($result);
+        $this->assertFalse(empty($result), "Result is empty");
     }
 
     /**

--- a/tests/TestCase/ModuleConfig/ModuleConfigTest.php
+++ b/tests/TestCase/ModuleConfig/ModuleConfigTest.php
@@ -111,6 +111,29 @@ class ModuleConfigTest extends TestCase
     }
 
     /**
+     * @dataProvider optionsProvider
+     * @param string $description Options description
+     * @param mixed[] $options Array of options
+     */
+    public function testParseToArray(string $description, array $options): void
+    {
+        $mc = new ModuleConfig(ConfigType::MODULE(), 'Foo', null, $options);
+        $resultObject = null;
+        $resultArray = null;
+        try {
+            $resultObject = $mc->parse();
+            $resultArray = $mc->parseToArray();
+        } catch (InvalidArgumentException $e) {
+            print_r($mc->getErrors());
+            $this->fail($e->getMessage());
+        }
+        $this->assertTrue(is_object($resultObject), "Result object is not an object");
+        $this->assertTrue(is_array($resultArray), "Result array is not an array");
+        $expected = Utility::objectToArray($resultObject);
+        $this->assertEquals($expected, $resultArray, "Result object is different from result array");
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @dataProvider optionsProvider
      * @param string $description Options description

--- a/tests/TestCase/ModuleConfig/Parser/Schema/SchemaTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/Schema/SchemaTest.php
@@ -37,8 +37,11 @@ class SchemaTest extends TestCase
             if (empty($realPath)) {
                 continue;
             }
-
             $content = file_get_contents($realPath);
+            if (empty($content)) {
+                $content = '';
+            }
+
             $this->assertFalse(empty($content), "Empty file or failed to read: " . $realPath);
             $data = json_decode($content);
             $this->assertFalse(empty($data), "Empty structure or failed to parse: " . $realPath);

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/ListParserTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\ListParser;
+use Qobo\Utils\Utility;
 
 class ListParserTest extends TestCase
 {
@@ -32,8 +33,7 @@ class ListParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['items']), "Parser returned empty items");
         $this->assertEquals(2, count($result['items']), "Parser returned incorrect count of list items");
@@ -56,8 +56,7 @@ class ListParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['items']), "Parser returned empty items");
         $this->assertEquals(3, count($result['items']), "Parser returned incorrect count of list items");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/MigrationParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/MigrationParserTest.php
@@ -4,6 +4,7 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Csv;
 use Cake\Core\Configure;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\MigrationParser;
+use Qobo\Utils\Utility;
 
 class MigrationParserTest extends TestCase
 {
@@ -25,8 +26,7 @@ class MigrationParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertTrue(array_key_exists('id', $result), "Parser missed 'id' field");
@@ -45,8 +45,7 @@ class MigrationParserTest extends TestCase
         $result = $this->parser->parse($file);
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertTrue(empty($result), "Parser returned empty result");
     }
@@ -58,8 +57,7 @@ class MigrationParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertTrue(empty($result), "Parser returned non-empty result");
     }
@@ -70,8 +68,7 @@ class MigrationParserTest extends TestCase
         $result = $this->parser->parse($file);
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
     }

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/ViewParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/ViewParserTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\ViewParser;
+use Qobo\Utils\Utility;
 
 class ViewParserTest extends TestCase
 {
@@ -35,7 +36,6 @@ class ViewParserTest extends TestCase
         $this->assertFalse(empty($result->items), "Parser returned empty items");
         $this->assertTrue(is_array($result->items), "Parser returned non-array items");
 
-        // Convert object to array recursively
         $result = $result->items;
 
         $this->assertTrue(is_array($result[0]), "Parser returned a non-array first element");
@@ -59,12 +59,9 @@ class ViewParserTest extends TestCase
         $this->assertFalse(empty($result->items), "Parser returned empty items");
         $this->assertTrue(is_array($result->items), "Parser returned non-array items");
 
-        // Convert object to array recursively
         $result = $result->items;
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
-
+        $this->assertFalse(empty($result[0]), "Parser returned an empty array");
         $this->assertTrue(is_array($result[0]), "Parser returned a non-array first element");
         $this->assertFalse(empty($result[0]), "Parser returned a non-array first element");
         $this->assertEquals(1, count($result[0]), "Parser returned incorrect number of items in first element");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/ConfigParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/ConfigParserTest.php
@@ -4,6 +4,7 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Ini;
 use Cake\Core\Configure;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\ConfigParser;
+use Qobo\Utils\Utility;
 
 class ConfigParserTest extends TestCase
 {
@@ -25,8 +26,7 @@ class ConfigParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
 
@@ -52,8 +52,7 @@ class ConfigParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
 
@@ -69,8 +68,7 @@ class ConfigParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertArrayHasKey('associations', $result, "No associations found in the table config");
         $this->assertArrayHasKey('association_labels', $result['associations'], "No associations found in the table config");
@@ -92,8 +90,7 @@ class ConfigParserTest extends TestCase
         $this->assertTrue(is_array($warnings), "Warnings is not an array");
         $this->assertFalse(empty($warnings), "Warnings are empty");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result['table']), "Parser missed 'table' section");
         $this->assertFalse(empty($result['table']['icon']), "Parser missed 'icon' default key");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/FieldsParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/FieldsParserTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\FieldsParser;
+use Qobo\Utils\Utility;
 
 class FieldsParserTest extends TestCase
 {
@@ -32,8 +33,7 @@ class FieldsParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['cost']), "Parser missed 'cost' section");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/ReportsParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/ReportsParserTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\ReportsParser;
+use Qobo\Utils\Utility;
 
 class ReportsParserTest extends TestCase
 {
@@ -32,8 +33,7 @@ class ReportsParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        // Convert object to array recursively
-        $result = json_decode(json_encode($result), true);
+        $result = Utility::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['by_campaign_name']), "Parser missed 'by_campaign_name' section");

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
@@ -4,6 +4,7 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V2\Json;
 use Cake\Core\Configure;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V2\Json\ListParser;
+use Qobo\Utils\Utility;
 
 class ListParserTest extends TestCase
 {
@@ -30,7 +31,7 @@ class ListParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file);
 
-        $resultArray = json_decode(json_encode($result), true);
+        $resultArray = Utility::objectToArray($result);
 
         $this->assertNotEmpty($result);
         $this->assertArrayHasKey('items', $resultArray);
@@ -42,7 +43,7 @@ class ListParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file, ['filter' => true]);
 
-        $resultArray = json_decode(json_encode($result), true);
+        $resultArray = Utility::objectToArray($result);
         $this->assertTrue(!in_array('foo', array_keys($resultArray['items'])));
     }
 
@@ -51,7 +52,7 @@ class ListParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file, ['filter' => true, 'flatten' => true]);
 
-        $resultArray = json_decode(json_encode($result), true);
+        $resultArray = Utility::objectToArray($result);
 
         $this->assertTrue(in_array('bar.bar_one', array_keys($resultArray['items'])));
         $this->assertTrue(in_array('bar.bar_two', array_keys($resultArray['items'])));

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ViewParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ViewParserTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V2\Json\ViewParser;
+use Qobo\Utils\Utility;
 
 class ViewParserTest extends TestCase
 {
@@ -30,7 +31,8 @@ class ViewParserTest extends TestCase
     {
         $file = $this->dataDir . DS . 'Foo' . DS . 'views' . DS . 'add.json';
 
-        $result = json_decode(json_encode($this->parser->parse($file)), true);
+        $result = $this->parser->parse($file);
+        $result = Utility::objectToArray($result);
 
         $this->assertNotEmpty($result);
         $this->assertArrayHasKey('items', $result);

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Qobo\Utils\Utility;
+use RuntimeException;
 use stdClass;
 
 class UtilityTest extends TestCase
@@ -317,9 +318,8 @@ class UtilityTest extends TestCase
         $result = Utility::objectToArray($source);
         $this->assertTrue(is_array($result));
         $this->assertTrue(empty($result));
-        if ($fh) {
-            fclose($fh);
-        }
+        // close file handler, cause we are nice people
+        fclose($fh);
 
         // object (good)
         $source = new stdClass();

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -5,6 +5,7 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Qobo\Utils\Utility;
+use stdClass;
 
 class UtilityTest extends TestCase
 {
@@ -292,5 +293,41 @@ class UtilityTest extends TestCase
 
         $clientIp = '82.102.92.178'; // CY
         $this->assertEquals(Utility::getCountryByIp($clientIp), $expected, 'Failed to receive correct code by public IP');
+    }
+
+    public function testObjectToArray(): void
+    {
+        // null
+        $result = Utility::objectToArray(null);
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(empty($result));
+
+        // scalar
+        $result = Utility::objectToArray('foobar');
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(empty($result));
+
+        // object with resource
+        $fh = fopen(__FILE__, "r");
+        if (!is_resource($fh)) {
+            throw new RuntimeException("Failed to open file for reading");
+        }
+        $source = new stdClass();
+        $source->foo = $fh;
+        $result = Utility::objectToArray($source);
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(empty($result));
+        if ($fh) {
+            fclose($fh);
+        }
+
+        // object (good)
+        $source = new stdClass();
+        $source->foo = 'bar';
+        $result = Utility::objectToArray($source);
+        $this->assertTrue(is_array($result));
+        $this->assertFalse(empty($result));
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertEquals('bar', $result['foo']);
     }
 }


### PR DESCRIPTION
We use the JSON encoding and decoding for converting objects to associative arrays quite intensively all throughout the codebase.  Now we have a helper method `objectToArray()` in the `Utility` class, as well as the `parseToArray()` method in the `ModuleConfig` class.

The codebase in this particular plugin has been already updated to utilize these methods.