### PR TITLE
Utils and PHPStan (task #8244)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
 
   include:
     - php: 7.1
-      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=1
     - php: 7.2
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: 7.3
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: nightly
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
   - composer validate --strict

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,7 +4,7 @@ use Burzum\FileStorage\Storage\StorageManager;
 use Burzum\FileStorage\Storage\StorageUtils;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 /**
  * Burzum File-Storage configuration
@@ -93,7 +93,7 @@ EventManager::instance()->on(new BaseListener(Configure::read('FileStorage')));
 function sizeToBytes($size)
 {
     try {
-        $result = Utility::valueToBytes($size);
+        $result = Convert::valueToBytes($size);
     } catch (Exception $e) {
         // Mimic initial behavior, before exception was introduced
         $result = (string)$size;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,8 @@ parameters:
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort
+    ignoreErrors:
+        - '#^Function geoip_country_code_by_name not found\.$#'
 includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
     - vendor/timeweb/phpstan-enum/extension.neon

--- a/src/Model/Behavior/FootprintBehavior.php
+++ b/src/Model/Behavior/FootprintBehavior.php
@@ -39,7 +39,7 @@ class FootprintBehavior extends Behavior
      * @param \ArrayObject $options Query options
      * @return void
      */
-    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
         if (! is_callable($this->getConfig('callback'))) {
             return;

--- a/src/ModuleConfig/ModuleConfig.php
+++ b/src/ModuleConfig/ModuleConfig.php
@@ -16,7 +16,7 @@ use Qobo\Utils\ErrorAwareInterface;
 use Qobo\Utils\ErrorTrait;
 use Qobo\Utils\ModuleConfig\Cache\Cache;
 use Qobo\Utils\ModuleConfig\Cache\PathCache;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 use stdClass;
 
 /**
@@ -203,7 +203,7 @@ class ModuleConfig implements ErrorAwareInterface
     public function parseToArray(): array
     {
         $result = $this->parse();
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         return $result;
     }

--- a/src/ModuleConfig/Parser/AbstractParser.php
+++ b/src/ModuleConfig/Parser/AbstractParser.php
@@ -125,19 +125,26 @@ abstract class AbstractParser implements ParserInterface
      * @param object $schema Schema to validate against
      * @return void
      */
-    protected function validateData($data, $schema)
+    protected function validateData($data = null, $schema = null)
     {
         // No need to validate empty data (empty() does not work on objects)
-        if (empty((array)$data)) {
+        $dataArray = Utility::objectToArray($data);
+        if (empty($dataArray)) {
             $this->warnings[] = "Skipping validation of empty data";
 
             return;
         }
 
         // No need to validate with empty schema (empty() does not work on objects)
-        if (empty((array)$schema)) {
+        $schemaArray = Utility::objectToArray($schema);
+        if (empty($schemaArray)) {
             $this->warnings[] = "Skipping validation with empty schema";
 
+            return;
+        }
+
+        // Strict typing
+        if (!is_object($schema)) {
             return;
         }
 

--- a/src/ModuleConfig/Parser/AbstractParser.php
+++ b/src/ModuleConfig/Parser/AbstractParser.php
@@ -125,7 +125,7 @@ abstract class AbstractParser implements ParserInterface
      * @param object $schema Schema to validate against
      * @return void
      */
-    protected function validateData($data = null, $schema = null)
+    protected function validateData($data = null, $schema = null): void
     {
         // No need to validate empty data (empty() does not work on objects)
         $dataArray = Utility::objectToArray($data);

--- a/src/ModuleConfig/Parser/AbstractParser.php
+++ b/src/ModuleConfig/Parser/AbstractParser.php
@@ -16,6 +16,7 @@ use League\JsonGuard\Dereferencer;
 use League\JsonGuard\Validator;
 use Qobo\Utils\ErrorTrait;
 use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 use stdClass;
 
 abstract class AbstractParser implements ParserInterface
@@ -128,7 +129,7 @@ abstract class AbstractParser implements ParserInterface
     protected function validateData($data = null, $schema = null): void
     {
         // No need to validate empty data (empty() does not work on objects)
-        $dataArray = Utility::objectToArray($data);
+        $dataArray = Convert::objectToArray($data);
         if (empty($dataArray)) {
             $this->warnings[] = "Skipping validation of empty data";
 
@@ -136,7 +137,7 @@ abstract class AbstractParser implements ParserInterface
         }
 
         // No need to validate with empty schema (empty() does not work on objects)
-        $schemaArray = Utility::objectToArray($schema);
+        $schemaArray = Convert::objectToArray($schema);
         if (empty($schemaArray)) {
             $this->warnings[] = "Skipping validation with empty schema";
 

--- a/src/ModuleConfig/Parser/V1/Csv/ListParser.php
+++ b/src/ModuleConfig/Parser/V1/Csv/ListParser.php
@@ -13,6 +13,7 @@ namespace Qobo\Utils\ModuleConfig\Parser\V1\Csv;
 
 use InvalidArgumentException;
 use Qobo\Utils\Utility;
+use stdClass;
 
 /**
  * List CSV Parser
@@ -107,7 +108,7 @@ class ListParser extends AbstractCsvParser
 
         $parser = new ListParser();
         $children = $parser->parse($childListPath);
-        $result = $children->items;
+        $result = property_exists($children, 'items') ? $children->items : [];
 
         return $result;
     }

--- a/src/ModuleConfig/Parser/V1/Csv/MigrationParser.php
+++ b/src/ModuleConfig/Parser/V1/Csv/MigrationParser.php
@@ -57,7 +57,7 @@ class MigrationParser extends AbstractCsvParser
     {
         $result = parent::getDataFromPath($path);
 
-        if (empty($result->items)) {
+        if (property_exists($result, 'items') && empty($result->items)) {
             unset($result->items);
 
             return $result;

--- a/src/ModuleConfig/Parser/V1/Ini/ConfigParser.php
+++ b/src/ModuleConfig/Parser/V1/Ini/ConfigParser.php
@@ -74,6 +74,10 @@ class ConfigParser extends AbstractIniParser
      */
     protected function mergeWithDefaults($data = null)
     {
+        if (!is_object($data)) {
+            $data = new stdClass();
+        }
+
         // Set defaults
         foreach ($this->defaults as $section => $options) {
             // Make sure the section exists
@@ -88,19 +92,35 @@ class ConfigParser extends AbstractIniParser
             }
         }
 
-        // Convert CSV string values to arrays
-        $data->table->lookup_fields = $this->csv2array($data->table->lookup_fields);
-        $data->table->typeahead_fields = $this->csv2array($data->table->typeahead_fields);
-        $data->table->permissions_parent_modules = $this->csv2array($data->table->permissions_parent_modules);
-        $data->table->basic_search_fields = $this->csv2array($data->table->basic_search_fields);
-        $data->table->allow_reminders = $this->csv2array($data->table->allow_reminders);
-        $data->associations->hide_associations = $this->csv2array($data->associations->hide_associations);
-        $data->notifications->ignored_fields = $this->csv2array($data->notifications->ignored_fields);
-        $data->manyToMany->modules = $this->csv2array($data->manyToMany->modules);
+        /*
+         * Convert CSV string values to arrays
+         */
 
-        $virtualFields = Utility::objectToArray($data->virtualFields);
-        foreach ($virtualFields as $virtualField => $realFields) {
-            $data->virtualFields->$virtualField = $this->csv2array($realFields);
+        if (property_exists($data, 'table')) {
+            $data->table->lookup_fields = $this->csv2array($data->table->lookup_fields);
+            $data->table->typeahead_fields = $this->csv2array($data->table->typeahead_fields);
+            $data->table->permissions_parent_modules = $this->csv2array($data->table->permissions_parent_modules);
+            $data->table->basic_search_fields = $this->csv2array($data->table->basic_search_fields);
+            $data->table->allow_reminders = $this->csv2array($data->table->allow_reminders);
+        }
+
+        if (property_exists($data, 'associations')) {
+            $data->associations->hide_associations = $this->csv2array($data->associations->hide_associations);
+        }
+
+        if (property_exists($data, 'notifications')) {
+            $data->notifications->ignored_fields = $this->csv2array($data->notifications->ignored_fields);
+        }
+
+        if (property_exists($data, 'manyToMany')) {
+            $data->manyToMany->modules = $this->csv2array($data->manyToMany->modules);
+        }
+
+        if (property_exists($data, 'virtualFields')) {
+            $virtualFields = Utility::objectToArray($data->virtualFields);
+            foreach ($virtualFields as $virtualField => $realFields) {
+                $data->virtualFields->$virtualField = $this->csv2array($realFields);
+            }
         }
 
         return $data;

--- a/src/ModuleConfig/Parser/V1/Ini/ConfigParser.php
+++ b/src/ModuleConfig/Parser/V1/Ini/ConfigParser.php
@@ -11,7 +11,7 @@
  */
 namespace Qobo\Utils\ModuleConfig\Parser\V1\Ini;
 
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 use stdClass;
 
 /**
@@ -117,7 +117,7 @@ class ConfigParser extends AbstractIniParser
         }
 
         if (property_exists($data, 'virtualFields')) {
-            $virtualFields = Utility::objectToArray($data->virtualFields);
+            $virtualFields = Convert::objectToArray($data->virtualFields);
             foreach ($virtualFields as $virtualField => $realFields) {
                 $data->virtualFields->$virtualField = $this->csv2array($realFields);
             }

--- a/src/ModuleConfig/Parser/V2/Json/ConfigParser.php
+++ b/src/ModuleConfig/Parser/V2/Json/ConfigParser.php
@@ -73,6 +73,10 @@ class ConfigParser extends AbstractJsonParser
      */
     protected function mergeWithDefaults($data = null)
     {
+        if (!is_object($data)) {
+            $data = new stdClass();
+        }
+
         // Set defaults
         foreach ($this->defaults as $section => $options) {
             // Make sure the section exists

--- a/src/ModuleConfig/Parser/V2/Json/ListParser.php
+++ b/src/ModuleConfig/Parser/V2/Json/ListParser.php
@@ -11,7 +11,7 @@
  */
 namespace Qobo\Utils\ModuleConfig\Parser\V2\Json;
 
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 /**
  * List JSON Parser
@@ -52,7 +52,7 @@ class ListParser extends AbstractJsonParser
         $options = array_merge($this->options, $options);
 
         $result = parent::parse($path, $options);
-        $data = Utility::objectToArray($result);
+        $data = Convert::objectToArray($result);
         if (empty($data['items'])) {
             $data['items'] = [];
         }
@@ -66,7 +66,7 @@ class ListParser extends AbstractJsonParser
             $data['items'] = $this->flatten($data['items']);
         }
 
-        $result = Utility::arrayToObject($data);
+        $result = Convert::arrayToObject($data);
 
         return $result;
     }

--- a/src/ModuleConfig/Parser/V2/Json/ListParser.php
+++ b/src/ModuleConfig/Parser/V2/Json/ListParser.php
@@ -53,15 +53,20 @@ class ListParser extends AbstractJsonParser
 
         $result = parent::parse($path, $options);
         $data = Utility::objectToArray($result);
-        $result->items = $this->normalize($data['items']);
+        if (empty($data['items'])) {
+            $data['items'] = [];
+        }
+        $data['items'] = $this->normalize($data['items']);
 
         if ($options['filter']) {
-            $result->items = $this->filter($result->items);
+            $data['items'] = $this->filter($data['items']);
         }
 
         if ($options['flatten']) {
-            $result->items = $this->flatten($result->items);
+            $data['items'] = $this->flatten($data['items']);
         }
+
+        $result = Utility::arrayToObject($data);
 
         return $result;
     }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -27,53 +27,6 @@ use UnexpectedValueException;
 class Utility
 {
     /**
-     * Convert value to bytes
-     *
-     * Convert sizes from PHP settings like post_max_size
-     * for example 8M to integer number of bytes.
-     *
-     * If number is integer return as is.
-     *
-     * NOTE: This is a modified copy from qobo/cakephp-utils/config/bootstrap.php
-     *
-     * @throws \InvalidArgumentException when cannot convert
-     * @param string|int $value Value to convert
-     * @return int
-     */
-    public static function valueToBytes($value): int
-    {
-        if (is_int($value)) {
-            return $value;
-        }
-
-        $value = trim($value);
-
-        // Native PHP check for digits in string
-        if (ctype_digit(ltrim($value, '-'))) {
-            return (int)$value;
-        }
-
-        $signed = (substr($value, 0, 1) === '-') ? -1 : 1;
-
-        // Kilobytes
-        if (preg_match('/(\d+)K$/i', $value, $matches)) {
-            return (int)($matches[1] * $signed * 1024);
-        }
-
-        // Megabytes
-        if (preg_match('/(\d+)M$/i', $value, $matches)) {
-            return (int)($matches[1] * $signed * 1024 * 1024);
-        }
-
-        // Gigabytes
-        if (preg_match('/(\d+)G$/i', $value, $matches)) {
-            return (int)($matches[1] * $signed * 1024 * 1024 * 1024);
-        }
-
-        throw new InvalidArgumentException("Failed to find K, M, or G in a non-integer value [$value]");
-    }
-
-    /**
      * Check validity of the given path
      *
      * @throws \InvalidArgumentException when path does not exist or is not readable
@@ -533,69 +486,5 @@ class Utility
         }
 
         return $clientCountryCode;
-    }
-
-    /**
-     * Convert an object to associative array
-     *
-     * NOTE: in case of any issues during the conversion, this
-     * method will return an empty array and NOT throw any
-     * exceptions.
-     *
-     * @param mixed $source Object to convert
-     * @return mixed[]
-     */
-    public static function objectToArray($source): array
-    {
-        $result = [];
-
-        if (is_array($source)) {
-            return $source;
-        }
-
-        if (!is_object($source)) {
-            return $result;
-        }
-
-        $json = json_encode($source);
-        if ($json === false) {
-            return $result;
-        }
-
-        $array = json_decode($json, true);
-        if ($array === null) {
-            return $result;
-        }
-        $result = $array;
-
-        return $result;
-    }
-
-    /**
-     * Convert an array to object
-     *
-     * NOTE: in case of any issues during the conversion, this
-     * method will return an empty \stdClass instance and NOT throw
-     * any exceptions.
-     *
-     * @param mixed[] $source Array to convert
-     * @return \stdClass
-     */
-    public static function arrayToObject(array $source): \stdClass
-    {
-        $result = new stdClass();
-
-        $json = json_encode($source);
-        if ($json === false) {
-            return $result;
-        }
-
-        $object = json_decode($json);
-        if ($object === null) {
-            return $result;
-        }
-        $result = $object;
-
-        return $result;
     }
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -21,6 +21,7 @@ use Cake\Filesystem\Folder;
 use Cake\Utility\Inflector;
 use DirectoryIterator;
 use InvalidArgumentException;
+use stdClass;
 use UnexpectedValueException;
 
 class Utility
@@ -45,7 +46,6 @@ class Utility
             return $value;
         }
 
-        $value = (string)$value;
         $value = trim($value);
 
         // Native PHP check for digits in string
@@ -110,7 +110,7 @@ class Utility
         }
 
         $plugins = Plugin::loaded();
-        if (empty($plugins)) {
+        if (!is_array($plugins)) {
             return $result;
         }
 
@@ -382,6 +382,7 @@ class Utility
         }
 
         $data = file_get_contents($config['url']);
+        $data = $data ?: '';
         preg_match_all($config['pattern'], $data, $matches);
 
         if (empty($matches[1])) {
@@ -566,6 +567,34 @@ class Utility
             return $result;
         }
         $result = $array;
+
+        return $result;
+    }
+
+    /**
+     * Convert an array to object
+     *
+     * NOTE: in case of any issues during the conversion, this
+     * method will return an empty \stdClass instance and NOT throw
+     * any exceptions.
+     *
+     * @param mixed[] $source Array to convert
+     * @return \stdClass
+     */
+    public static function arrayToObject(array $source): \stdClass
+    {
+        $result = new stdClass();
+
+        $json = json_encode($source);
+        if ($json === false) {
+            return $result;
+        }
+
+        $object = json_decode($json);
+        if ($object === null) {
+            return $result;
+        }
+        $result = $object;
 
         return $result;
     }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -80,7 +80,7 @@ class Utility
      * @param string $path Path to validate
      * @return void
      */
-    public static function validatePath(string $path = null)
+    public static function validatePath(string $path = null): void
     {
         if (empty($path)) {
             throw new InvalidArgumentException("Cannot validate empty path");

--- a/src/Utility/Convert.php
+++ b/src/Utility/Convert.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Utility;
+
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * Convert Class
+ *
+ * This class provides a variety of helper methods
+ * to convert data between different formats, structures,
+ * and the like.
+ */
+class Convert
+{
+    /**
+     * Convert value to bytes
+     *
+     * Convert sizes from PHP settings like post_max_size
+     * for example 8M to integer number of bytes.
+     *
+     * If number is integer return as is.
+     *
+     * NOTE: This is a modified copy from qobo/cakephp-utils/config/bootstrap.php
+     *
+     * @throws \InvalidArgumentException when cannot convert
+     * @param string|int $value Value to convert
+     * @return int
+     */
+    public static function valueToBytes($value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        $value = trim($value);
+
+        // Native PHP check for digits in string
+        if (ctype_digit(ltrim($value, '-'))) {
+            return (int)$value;
+        }
+
+        $signed = (substr($value, 0, 1) === '-') ? -1 : 1;
+
+        // Kilobytes
+        if (preg_match('/(\d+)K$/i', $value, $matches)) {
+            return (int)($matches[1] * $signed * 1024);
+        }
+
+        // Megabytes
+        if (preg_match('/(\d+)M$/i', $value, $matches)) {
+            return (int)($matches[1] * $signed * 1024 * 1024);
+        }
+
+        // Gigabytes
+        if (preg_match('/(\d+)G$/i', $value, $matches)) {
+            return (int)($matches[1] * $signed * 1024 * 1024 * 1024);
+        }
+
+        throw new InvalidArgumentException("Failed to find K, M, or G in a non-integer value [$value]");
+    }
+
+    /**
+     * Convert an object to associative array
+     *
+     * NOTE: in case of any issues during the conversion, this
+     * method will return an empty array and NOT throw any
+     * exceptions.
+     *
+     * @param mixed $source Object to convert
+     * @return mixed[]
+     */
+    public static function objectToArray($source): array
+    {
+        $result = [];
+
+        if (is_array($source)) {
+            return $source;
+        }
+
+        if (!is_object($source)) {
+            return $result;
+        }
+
+        $json = json_encode($source);
+        if ($json === false) {
+            return $result;
+        }
+
+        $array = json_decode($json, true);
+        if ($array === null) {
+            return $result;
+        }
+        $result = $array;
+
+        return $result;
+    }
+
+    /**
+     * Convert an array to object
+     *
+     * NOTE: in case of any issues during the conversion, this
+     * method will return an empty \stdClass instance and NOT throw
+     * any exceptions.
+     *
+     * @param mixed[] $source Array to convert
+     * @return \stdClass
+     */
+    public static function arrayToObject(array $source): \stdClass
+    {
+        $result = new stdClass();
+
+        $json = json_encode($source);
+        if ($json === false) {
+            return $result;
+        }
+
+        $object = json_decode($json);
+        if ($object === null) {
+            return $result;
+        }
+        $result = $object;
+
+        return $result;
+    }
+}

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -10,7 +10,7 @@ class UsersController extends Controller
      *
      * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/TestCase/ModuleConfig/Cache/CacheTest.php
+++ b/tests/TestCase/ModuleConfig/Cache/CacheTest.php
@@ -61,7 +61,9 @@ class CacheTest extends TestCase
         ];
         $paramsAll = $params;
         $paramsAll[] = $options;
-        $expected = 'foo_' . md5(json_encode($paramsAll));
+        $paramsAllJson = json_encode($paramsAll);
+        $paramsAllJson = $paramsAllJson ?: '';
+        $expected = 'foo_' . md5($paramsAllJson);
 
         $cache = new Cache('foo', $options);
         $result = $cache->getKey($params);

--- a/tests/TestCase/ModuleConfig/ModuleConfigTest.php
+++ b/tests/TestCase/ModuleConfig/ModuleConfigTest.php
@@ -6,7 +6,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Qobo\Utils\ModuleConfig\ConfigType;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class ModuleConfigTest extends TestCase
 {
@@ -106,7 +106,7 @@ class ModuleConfigTest extends TestCase
             $this->fail($e->getMessage());
         }
         $this->assertTrue(is_object($result), "Result is not an object");
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
         $this->assertFalse(empty($result), "Result is empty");
     }
 
@@ -129,7 +129,7 @@ class ModuleConfigTest extends TestCase
         }
         $this->assertTrue(is_object($resultObject), "Result object is not an object");
         $this->assertTrue(is_array($resultArray), "Result array is not an array");
-        $expected = Utility::objectToArray($resultObject);
+        $expected = Convert::objectToArray($resultObject);
         $this->assertEquals($expected, $resultArray, "Result object is different from result array");
     }
 

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/ListParserTest.php
@@ -5,7 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\ListParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class ListParserTest extends TestCase
 {
@@ -33,7 +33,7 @@ class ListParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['items']), "Parser returned empty items");
         $this->assertEquals(2, count($result['items']), "Parser returned incorrect count of list items");
@@ -56,7 +56,7 @@ class ListParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['items']), "Parser returned empty items");
         $this->assertEquals(3, count($result['items']), "Parser returned incorrect count of list items");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Csv/MigrationParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Csv/MigrationParserTest.php
@@ -4,7 +4,7 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Csv;
 use Cake\Core\Configure;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Csv\MigrationParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class MigrationParserTest extends TestCase
 {
@@ -26,7 +26,7 @@ class MigrationParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertTrue(array_key_exists('id', $result), "Parser missed 'id' field");
@@ -45,7 +45,7 @@ class MigrationParserTest extends TestCase
         $result = $this->parser->parse($file);
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertTrue(empty($result), "Parser returned empty result");
     }
@@ -57,7 +57,7 @@ class MigrationParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertTrue(empty($result), "Parser returned non-empty result");
     }
@@ -68,7 +68,7 @@ class MigrationParserTest extends TestCase
         $result = $this->parser->parse($file);
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
     }

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/ConfigParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/ConfigParserTest.php
@@ -4,7 +4,7 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V1\Ini;
 use Cake\Core\Configure;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\ConfigParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class ConfigParserTest extends TestCase
 {
@@ -26,7 +26,7 @@ class ConfigParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
 
@@ -52,7 +52,7 @@ class ConfigParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
 
@@ -68,7 +68,7 @@ class ConfigParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertArrayHasKey('associations', $result, "No associations found in the table config");
         $this->assertArrayHasKey('association_labels', $result['associations'], "No associations found in the table config");
@@ -90,7 +90,7 @@ class ConfigParserTest extends TestCase
         $this->assertTrue(is_array($warnings), "Warnings is not an array");
         $this->assertFalse(empty($warnings), "Warnings are empty");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result['table']), "Parser missed 'table' section");
         $this->assertFalse(empty($result['table']['icon']), "Parser missed 'icon' default key");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/FieldsParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/FieldsParserTest.php
@@ -5,7 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\FieldsParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class FieldsParserTest extends TestCase
 {
@@ -33,7 +33,7 @@ class FieldsParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['cost']), "Parser missed 'cost' section");

--- a/tests/TestCase/ModuleConfig/Parser/V1/Ini/ReportsParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V1/Ini/ReportsParserTest.php
@@ -5,7 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V1\Ini\ReportsParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class ReportsParserTest extends TestCase
 {
@@ -33,7 +33,7 @@ class ReportsParserTest extends TestCase
 
         $this->assertTrue(is_object($result), "Parser returned a non-object");
 
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertFalse(empty($result), "Parser returned empty result");
         $this->assertFalse(empty($result['by_campaign_name']), "Parser missed 'by_campaign_name' section");

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ListParserTest.php
@@ -4,7 +4,7 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser\V2\Json;
 use Cake\Core\Configure;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V2\Json\ListParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class ListParserTest extends TestCase
 {
@@ -31,7 +31,7 @@ class ListParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file);
 
-        $resultArray = Utility::objectToArray($result);
+        $resultArray = Convert::objectToArray($result);
 
         $this->assertNotEmpty($result);
         $this->assertArrayHasKey('items', $resultArray);
@@ -43,7 +43,7 @@ class ListParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file, ['filter' => true]);
 
-        $resultArray = Utility::objectToArray($result);
+        $resultArray = Convert::objectToArray($result);
         $this->assertTrue(!in_array('foo', array_keys($resultArray['items'])));
     }
 
@@ -52,7 +52,7 @@ class ListParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'lists' . DS . 'local_genders.json';
         $result = $this->parser->parse($file, ['filter' => true, 'flatten' => true]);
 
-        $resultArray = Utility::objectToArray($result);
+        $resultArray = Convert::objectToArray($result);
 
         $this->assertTrue(in_array('bar.bar_one', array_keys($resultArray['items'])));
         $this->assertTrue(in_array('bar.bar_two', array_keys($resultArray['items'])));

--- a/tests/TestCase/ModuleConfig/Parser/V2/Json/ViewParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/V2/Json/ViewParserTest.php
@@ -5,7 +5,7 @@ use Cake\Core\Configure;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\V2\Json\ViewParser;
-use Qobo\Utils\Utility;
+use Qobo\Utils\Utility\Convert;
 
 class ViewParserTest extends TestCase
 {
@@ -32,7 +32,7 @@ class ViewParserTest extends TestCase
         $file = $this->dataDir . DS . 'Foo' . DS . 'views' . DS . 'add.json';
 
         $result = $this->parser->parse($file);
-        $result = Utility::objectToArray($result);
+        $result = Convert::objectToArray($result);
 
         $this->assertNotEmpty($result);
         $this->assertArrayHasKey('items', $result);

--- a/tests/TestCase/Utility/ConvertTest.php
+++ b/tests/TestCase/Utility/ConvertTest.php
@@ -1,0 +1,119 @@
+<?php
+namespace Qobo\Utils\Test\TestCase\Utility;
+
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use Qobo\Utils\Utility\Convert;
+use RuntimeException;
+use stdClass;
+
+class ConvertTest extends TestCase
+{
+    /**
+     * @return mixed[]
+     */
+    public function valueBytesProvider(): array
+    {
+        return [
+            [-42, -42, 'Negative integer value'],
+            [42, 42, 'Positive integer value'],
+
+            ['-42', -42, 'Negative integer as string'],
+            ['42', 42, 'Positive integer as string'],
+
+            ['-42k', -43008, 'Negative lowercase kilobytes'],
+            ['42k', 43008, 'Positive lowercase kilobytes'],
+
+            ['-42K', -43008, 'Negative uppercase kilobytes'],
+            ['42K', 43008, 'Positive uppercase kilobytes'],
+
+            ['-42m', -44040192, 'Negative lowercase megabytes'],
+            ['42m', 44040192, 'Positive lowercase megabytes'],
+
+            ['-42M', -44040192, 'Negative uppercase megabytes'],
+            ['42M', 44040192, 'Positive uppercase megabytes'],
+
+            ['-42g', -45097156608, 'Negative lowercase gigabytes'],
+            ['42g', 45097156608, 'Positive lowercase gigabytes'],
+
+            ['-42G', -45097156608, 'Negative uppercase gigabytes'],
+            ['42G', 45097156608, 'Positive uppercase gigabytes'],
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @dataProvider valueBytesProvider
+     */
+    public function testValueToBytes($value, int $expected, string $description): void
+    {
+        $result = Convert::valueToBytes($value);
+        $this->assertEquals($expected, $result, "valueToBytes() failed for: $description");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testValueToBytesException(): void
+    {
+        $result = Convert::valueToBytes('this is not a byte size value');
+    }
+
+    public function testObjectToArray(): void
+    {
+        // null
+        $result = Convert::objectToArray(null);
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(empty($result));
+
+        // scalar
+        $result = Convert::objectToArray('foobar');
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(empty($result));
+
+        // object with resource
+        $fh = fopen(__FILE__, "r");
+        if (!is_resource($fh)) {
+            throw new RuntimeException("Failed to open file for reading");
+        }
+        $source = new stdClass();
+        $source->foo = $fh;
+        $result = Convert::objectToArray($source);
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(empty($result));
+        // close file handler, cause we are nice people
+        fclose($fh);
+
+        // object (good)
+        $source = new stdClass();
+        $source->foo = 'bar';
+        $result = Convert::objectToArray($source);
+        $this->assertTrue(is_array($result));
+        $this->assertFalse(empty($result));
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertEquals('bar', $result['foo']);
+    }
+
+    public function testArrayToObject(): void
+    {
+        // array with resource
+        $fh = fopen(__FILE__, "r");
+        if (!is_resource($fh)) {
+            throw new RuntimeException("Failed to open file for reading");
+        }
+        $source = [];
+        $source['foo'] = $fh;
+        $result = Convert::arrayToObject($source);
+        $this->assertTrue(is_object($result));
+        // close file handler, cause we are nice people
+        fclose($fh);
+
+        // array (good)
+        $source = [];
+        $source['foo'] = 'bar';
+        $result = Convert::arrayToObject($source);
+        $this->assertTrue(is_object($result));
+        $this->assertTrue(property_exists($result, 'foo'));
+        $this->assertEquals('bar', $result->foo);
+    }
+}

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -330,4 +330,27 @@ class UtilityTest extends TestCase
         $this->assertArrayHasKey('foo', $result);
         $this->assertEquals('bar', $result['foo']);
     }
+
+    public function testArrayToObject(): void
+    {
+        // array with resource
+        $fh = fopen(__FILE__, "r");
+        if (!is_resource($fh)) {
+            throw new RuntimeException("Failed to open file for reading");
+        }
+        $source = [];
+        $source['foo'] = $fh;
+        $result = Utility::arrayToObject($source);
+        $this->assertTrue(is_object($result));
+        // close file handler, cause we are nice people
+        fclose($fh);
+
+        // array (good)
+        $source = [];
+        $source['foo'] = 'bar';
+        $result = Utility::arrayToObject($source);
+        $this->assertTrue(is_object($result));
+        $this->assertTrue(property_exists($result, 'foo'));
+        $this->assertEquals('bar', $result->foo);
+    }
 }

--- a/tests/TestCase/UtilityTest.php
+++ b/tests/TestCase/UtilityTest.php
@@ -5,64 +5,12 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Qobo\Utils\Utility;
-use RuntimeException;
-use stdClass;
 
 class UtilityTest extends TestCase
 {
     public $fixtures = [
         'plugin.CakeDC/Users.users'
     ];
-
-    /**
-     * @return mixed[]
-     */
-    public function valueBytesProvider(): array
-    {
-        return [
-            [-42, -42, 'Negative integer value'],
-            [42, 42, 'Positive integer value'],
-
-            ['-42', -42, 'Negative integer as string'],
-            ['42', 42, 'Positive integer as string'],
-
-            ['-42k', -43008, 'Negative lowercase kilobytes'],
-            ['42k', 43008, 'Positive lowercase kilobytes'],
-
-            ['-42K', -43008, 'Negative uppercase kilobytes'],
-            ['42K', 43008, 'Positive uppercase kilobytes'],
-
-            ['-42m', -44040192, 'Negative lowercase megabytes'],
-            ['42m', 44040192, 'Positive lowercase megabytes'],
-
-            ['-42M', -44040192, 'Negative uppercase megabytes'],
-            ['42M', 44040192, 'Positive uppercase megabytes'],
-
-            ['-42g', -45097156608, 'Negative lowercase gigabytes'],
-            ['42g', 45097156608, 'Positive lowercase gigabytes'],
-
-            ['-42G', -45097156608, 'Negative uppercase gigabytes'],
-            ['42G', 45097156608, 'Positive uppercase gigabytes'],
-        ];
-    }
-
-    /**
-     * @param mixed $value
-     * @dataProvider valueBytesProvider
-     */
-    public function testValueToBytes($value, int $expected, string $description): void
-    {
-        $result = Utility::valueToBytes($value);
-        $this->assertEquals($expected, $result, "valueToBytes() failed for: $description");
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testValueToBytesException(): void
-    {
-        $result = Utility::valueToBytes('this is not a byte size value');
-    }
 
     /**
      * @expectedException \InvalidArgumentException
@@ -294,63 +242,5 @@ class UtilityTest extends TestCase
 
         $clientIp = '82.102.92.178'; // CY
         $this->assertEquals(Utility::getCountryByIp($clientIp), $expected, 'Failed to receive correct code by public IP');
-    }
-
-    public function testObjectToArray(): void
-    {
-        // null
-        $result = Utility::objectToArray(null);
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(empty($result));
-
-        // scalar
-        $result = Utility::objectToArray('foobar');
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(empty($result));
-
-        // object with resource
-        $fh = fopen(__FILE__, "r");
-        if (!is_resource($fh)) {
-            throw new RuntimeException("Failed to open file for reading");
-        }
-        $source = new stdClass();
-        $source->foo = $fh;
-        $result = Utility::objectToArray($source);
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(empty($result));
-        // close file handler, cause we are nice people
-        fclose($fh);
-
-        // object (good)
-        $source = new stdClass();
-        $source->foo = 'bar';
-        $result = Utility::objectToArray($source);
-        $this->assertTrue(is_array($result));
-        $this->assertFalse(empty($result));
-        $this->assertArrayHasKey('foo', $result);
-        $this->assertEquals('bar', $result['foo']);
-    }
-
-    public function testArrayToObject(): void
-    {
-        // array with resource
-        $fh = fopen(__FILE__, "r");
-        if (!is_resource($fh)) {
-            throw new RuntimeException("Failed to open file for reading");
-        }
-        $source = [];
-        $source['foo'] = $fh;
-        $result = Utility::arrayToObject($source);
-        $this->assertTrue(is_object($result));
-        // close file handler, cause we are nice people
-        fclose($fh);
-
-        // array (good)
-        $source = [];
-        $source['foo'] = 'bar';
-        $result = Utility::arrayToObject($source);
-        $this->assertTrue(is_object($result));
-        $this->assertTrue(property_exists($result, 'foo'));
-        $this->assertEquals('bar', $result->foo);
     }
 }


### PR DESCRIPTION
* Added `Convert` class to Utilities.
* Moved `valueToBytes()` method to `Convert` class.
* Moved `objectToArray()` method to `Convert` class.
* Added `arrayToObject()` method to `Convert` class.
* Updated codebase (`src/`, `config/`).
* Updated unit tests.
* Fixed all PHPStan errors.
* Enabled PHPStan during TravisCI test runs.