### PR TITLE
Use CakePHP 3.6 compatible burzum plugins (task #8512)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
-  - composer validate --strict
+  - composer validate
   - composer install --no-interaction --no-progress --no-suggest
   - mkdir -p build/test-coverage build/test-results
 

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,19 @@
             "php": "7.1"
         }
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
+        }
+    ],
     "require": {
         "admad/cakephp-jwt-auth": "^2.0",
         "admad/cakephp-sequence": "^2.2",
         "alt3/cakephp-swagger": "^2.0",
         "arvenil/ninja-mutex": "^0.6",
-        "burzum/cakephp-file-storage": "^1.2",
-        "burzum/cakephp-imagine-plugin": "^2.1",
+        "burzum/cakephp-file-storage": "dev-branch-2.0",
+        "burzum/cakephp-imagine-plugin": "3.x-dev",
         "cakedc/users": "^7.0",
         "cakephp/cakephp": "^3.5",
         "cakephp/migrations": "^1.7",


### PR DESCRIPTION
* Use 3.x branch of cakephp-imagine-plugin
* Use branch-2.0 of cakephp-file-storage from custom fork
* Temporarily disable strict validation of `composer.json`