### PR TITLE
Bugfix for empty obj treated as arrays and validation fails (task #8712)

### DIFF
--- a/src/ModuleConfig/Parser/Schema/config.json
+++ b/src/ModuleConfig/Parser/Schema/config.json
@@ -284,9 +284,9 @@
         "virtualFields": {
             "title": "Module virtual fields configuration",
             "description": "List of virtual fields and their mapping to real fields for SQL queries",
-            "type": "object",
+            "type": ["array", "object"],
             "properties": {},
-            "default": {},
+            "default": [],
             "additionalProperties": {
                 "anyOf": [
                     { "type": "string" },
@@ -457,9 +457,9 @@
         "associationLabels": {
             "title": "Association labels",
             "description": "Defines custom labels for association tabs",
-            "type": "object",
+            "type": ["array", "object"],
             "properties": {},
-            "default": {},
+            "default": [],
             "additionalProperties": {
                 "allOf": [
                     { "type": ["string"] }


### PR DESCRIPTION
Workaround for a bug in the external json validator (https://github.com/justinrainbow/json-schema) which causes default empty objects to be transformed into an empty array, which in turns fails validation when arrays are not specified in the `type` parameter.