### PR TITLE
Do not skip non-dist common lists (task #9017)

### DIFF
--- a/src/ModuleConfig/PathFinder/BasePathFinder.php
+++ b/src/ModuleConfig/PathFinder/BasePathFinder.php
@@ -81,12 +81,12 @@ abstract class BasePathFinder implements PathFinderInterface
             $distributionPath = $this->getDistributionFilePath($path);
 
             // We rethrow the exception, only if the validate flag is enabled
-            if ($validate && $distributionPath === $path) {
+            if ($validate && $this->isDistributionFilePath($path)) {
                 throw $e;
             }
 
             // Try to find the distribution file
-            if ($distributionPath !== $path) {
+            if (!$this->isDistributionFilePath($path)) {
                 $result = $this->find($module, $distributionPath, $validate);
             }
         }
@@ -154,6 +154,17 @@ abstract class BasePathFinder implements PathFinderInterface
         }
 
         return $path;
+    }
+
+    /**
+     * Returns true only and only if the provided file path is a distribution path
+     *
+     * @param string $path File path
+     * @return bool
+     */
+    protected function isDistributionFilePath(string $path): bool
+    {
+        return $this->getDistributionFilePath($path) === $path;
     }
 
     /**

--- a/src/ModuleConfig/PathFinder/V2/ListPathFinder.php
+++ b/src/ModuleConfig/PathFinder/V2/ListPathFinder.php
@@ -78,7 +78,8 @@ class ListPathFinder extends BasePathFinder
             }
         }
 
-        if (($result === null) && ($module <> self::DEFAULT_MODULE)) {
+        $distributionPath = $this->getDistributionFilePath($path);
+        if (($distributionPath !== $path) && ($result === null) && ($module <> self::DEFAULT_MODULE)) {
             $this->warnings[] = "Module list not found.  Falling back on module " . self::DEFAULT_MODULE;
             $result = parent::find(self::DEFAULT_MODULE, $path, true);
         }

--- a/src/ModuleConfig/PathFinder/V2/ListPathFinder.php
+++ b/src/ModuleConfig/PathFinder/V2/ListPathFinder.php
@@ -78,8 +78,9 @@ class ListPathFinder extends BasePathFinder
             }
         }
 
-        $distributionPath = $this->getDistributionFilePath($path);
-        if (($distributionPath !== $path) && ($result === null) && ($module <> self::DEFAULT_MODULE)) {
+        // Module list was not found so we are falling back to the default module
+        // We ignore distribution files so that we will attempt to load custom file as well
+        if (!$this->isDistributionFilePath($path) && ($result === null) && ($module <> self::DEFAULT_MODULE)) {
             $this->warnings[] = "Module list not found.  Falling back on module " . self::DEFAULT_MODULE;
             $result = parent::find(self::DEFAULT_MODULE, $path, true);
         }


### PR DESCRIPTION
When loading lists we would skip custom lists defined under the default (Common) module. Previously, the sequence was `ModuleName/lists/list.json -> ModuleName/lists/list.dist.json -> Common/lists/list.dist.json`

The new sequence is `ModuleName/lists/list.json -> ModuleName/lists/list.dist.json -> Common/lists/list.json -> Common/lists/list.dist.json`