### PR TITLE
Add support for CSRF token (task #7073)

### DIFF
--- a/webroot/js/dataTables.init.js
+++ b/webroot/js/dataTables.init.js
@@ -183,6 +183,11 @@ DataTablesInit.prototype = {
             var $form = $(
                 '<form method="post" action="' + $(this).data('batch-url') + '"></form>'
             );
+
+            if ($(this).data('csrf-token')) {
+                $form.append('<input type="text" name="_csrfToken" value="' + $(this).data('csrf-token') + '">');
+            }
+
             $('#' + table.table().node().id + ' tr.selected').each(function () {
                 $form.append('<input type="text" name="batch[ids][]" value="' + $(this).attr('data-id') + '">');
             });


### PR DESCRIPTION
Extends the implementation for batch actions (edit, delete) to allow passing the CSRF Token through HTML data attributes. The provided token is added as text input when generating the form to be submitted.
