### PR TITLE
Improve type hints and checks (task #9606)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,10 +50,12 @@
         "mobiledetect/mobiledetectlib": "2.*",
         "muffin/trash": "^2.1",
         "myclabs/php-enum": "^1.5",
+        "phpstan/phpstan-webmozart-assert": "^0.10",
         "pyrech/composer-changelogs": "^1.4",
         "riesenia/cakephp-duplicatable": "^3.0",
         "rlanvin/php-rrule": "^1.6",
-        "seld/jsonlint": "^1.7"
+        "seld/jsonlint": "^1.7",
+        "webmozart/assert": "^1.4"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
         "mobiledetect/mobiledetectlib": "2.*",
         "muffin/trash": "^2.1",
         "myclabs/php-enum": "^1.5",
-        "phpstan/phpstan-webmozart-assert": "^0.10",
         "pyrech/composer-changelogs": "^1.4",
         "riesenia/cakephp-duplicatable": "^3.0",
         "rlanvin/php-rrule": "^1.6",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,7 +4,6 @@ use Burzum\FileStorage\Storage\StorageManager;
 use Burzum\FileStorage\Storage\StorageUtils;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
-use Qobo\Utils\Utility\Convert;
 
 /**
  * Burzum File-Storage configuration

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,5 +12,6 @@ parameters:
     ignoreErrors:
         - '#^Function geoip_country_code_by_name not found\.$#'
 includes:
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
     - vendor/timeweb/phpstan-enum/extension.neon

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Qobo\Utils;
+
+interface ConfigInterface
+{
+    /**
+     * Sets the config.
+     *
+     * @param string|array $key The key to set, or a complete array of configs.
+     * @param mixed|null $value The value to set.
+     * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
+     * @return $this
+     * @throws \Cake\Core\Exception\Exception When trying to set a key that is invalid.
+     */
+    public function setConfig($key, $value = null, bool $merge = true);
+
+    /**
+     * Returns the config.
+     *
+     * @param string|null $key The key to get or null for the whole config.
+     * @param mixed $default The return value when the key does not exist.
+     * @return mixed Config value being read.
+     */
+    public function getConfig(?string $key = null, $default = null);
+}

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -9,18 +9,18 @@ interface ConfigInterface
      *
      * @param string|array $key The key to set, or a complete array of configs.
      * @param mixed|null $value The value to set.
-     * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
+     * @param mixed $merge Whether to recursively merge or overwrite existing config, defaults to true.
      * @return $this
      * @throws \Cake\Core\Exception\Exception When trying to set a key that is invalid.
      */
-    public function setConfig($key, $value = null, bool $merge = true);
+    public function setConfig($key, $value = null, $merge = true);
 
     /**
      * Returns the config.
      *
-     * @param string|null $key The key to get or null for the whole config.
+     * @param mixed $key The key to get or null for the whole config.
      * @param mixed $default The return value when the key does not exist.
      * @return mixed Config value being read.
      */
-    public function getConfig(?string $key = null, $default = null);
+    public function getConfig($key = null, $default = null);
 }

--- a/src/ModuleConfig/Cache/Cache.php
+++ b/src/ModuleConfig/Cache/Cache.php
@@ -231,13 +231,12 @@ class Cache implements ErrorAwareInterface
             $cachedData = $data;
         }
 
-        /** @var bool|null */
         $result = CakeCache::write($key, $cachedData, $this->getConfig());
         if (!$result) {
             $this->errors[] = 'Failed to write value to cache';
         }
 
-        return is_bool($result) ? $result : (bool)$result;
+        return $result;
     }
 
     /**

--- a/src/ModuleConfig/ClassFactory.php
+++ b/src/ModuleConfig/ClassFactory.php
@@ -13,7 +13,9 @@ namespace Qobo\Utils\ModuleConfig;
 
 use Cake\Core\Configure;
 use InvalidArgumentException;
+use Qobo\Utils\ModuleConfig\Parser\ParserInterface;
 use ReflectionClass;
+use Webmozart\Assert\Assert;
 
 /**
  * ClassFactory Class
@@ -51,6 +53,24 @@ class ClassFactory
         $result = static::getInstance($className, $params);
 
         return $result;
+    }
+
+    /**
+     * Create a new instance of a Parser class
+     *
+     * Options:
+     * - classArgs: array of class arguments which will be passed to the constructor.
+     *
+     * @param string $configType Configuration type
+     * @param mixed[] $options Options
+     * @return \Qobo\Utils\ModuleConfig\Parser\ParserInterface
+     */
+    public static function createParser(string $configType, array $options = []): ParserInterface
+    {
+        $parser = self::create($configType, ClassType::PARSER(), $options);
+        Assert::isInstanceOf($parser, ParserInterface::class);
+
+        return $parser;
     }
 
     /**

--- a/src/ModuleConfig/ClassFactory.php
+++ b/src/ModuleConfig/ClassFactory.php
@@ -14,6 +14,7 @@ namespace Qobo\Utils\ModuleConfig;
 use Cake\Core\Configure;
 use InvalidArgumentException;
 use Qobo\Utils\ModuleConfig\Parser\ParserInterface;
+use Qobo\Utils\ModuleConfig\PathFinder\PathFinderInterface;
 use ReflectionClass;
 use Webmozart\Assert\Assert;
 
@@ -69,6 +70,24 @@ class ClassFactory
     {
         $parser = self::create($configType, ClassType::PARSER(), $options);
         Assert::isInstanceOf($parser, ParserInterface::class);
+
+        return $parser;
+    }
+
+    /**
+     * Create a new instance of a Parser class
+     *
+     * Options:
+     * - classArgs: array of class arguments which will be passed to the constructor.
+     *
+     * @param string $configType Configuration type
+     * @param mixed[] $options Options
+     * @return \Qobo\Utils\ModuleConfig\PathFinder\PathFinderInterface
+     */
+    public static function createFinder(string $configType, array $options = []): PathFinderInterface
+    {
+        $parser = self::create($configType, ClassType::FINDER(), $options);
+        Assert::isInstanceOf($parser, PathFinderInterface::class);
 
         return $parser;
     }

--- a/src/ModuleConfig/ModuleConfig.php
+++ b/src/ModuleConfig/ModuleConfig.php
@@ -13,6 +13,7 @@ namespace Qobo\Utils\ModuleConfig;
 
 use Cake\Core\Configure;
 use InvalidArgumentException;
+use Qobo\Utils\ConfigInterface;
 use Qobo\Utils\ErrorAwareInterface;
 use Qobo\Utils\ErrorTrait;
 use Qobo\Utils\ModuleConfig\Cache\Cache;
@@ -150,10 +151,8 @@ class ModuleConfig implements ErrorAwareInterface
         if (is_null($parser)) {
             $options = array_merge($this->options, ['classArgs' => [$this->createSchema()]]);
 
-            /** @var \Qobo\Utils\ModuleConfig\Parser\ParserInterface&\Cake\Core\InstanceConfigTrait $parser */
-            $parser = ClassFactory::create($this->configType, ClassType::PARSER(), $options);
-
-            if (!empty($this->options)) {
+            $parser = ClassFactory::createParser($this->configType, $options);
+            if (!empty($this->options) && $parser instanceof ConfigInterface) {
                 $parser->setConfig($this->options);
             }
         }

--- a/src/ModuleConfig/ModuleConfig.php
+++ b/src/ModuleConfig/ModuleConfig.php
@@ -21,6 +21,7 @@ use Qobo\Utils\ModuleConfig\Cache\PathCache;
 use Qobo\Utils\ModuleConfig\Parser\ParserInterface;
 use Qobo\Utils\ModuleConfig\Parser\Schema;
 use Qobo\Utils\ModuleConfig\Parser\SchemaInterface;
+use Qobo\Utils\ModuleConfig\PathFinder\PathFinderInterface;
 use Qobo\Utils\Utility\Convert;
 use stdClass;
 
@@ -103,12 +104,9 @@ class ModuleConfig implements ErrorAwareInterface
      *
      * @return \Qobo\Utils\ModuleConfig\PathFinder\PathFinderInterface
      */
-    protected function getFinder(): \Qobo\Utils\ModuleConfig\PathFinder\PathFinderInterface
+    protected function getFinder(): PathFinderInterface
     {
-        /**
-         * @var \Qobo\Utils\ModuleConfig\PathFinder\PathFinderInterface $result
-         */
-        $result = ClassFactory::create($this->configType, ClassType::FINDER(), $this->options);
+        $result = ClassFactory::createFinder($this->configType, $this->options);
 
         return $result;
     }

--- a/src/ModuleConfig/Parser/Parser.php
+++ b/src/ModuleConfig/Parser/Parser.php
@@ -14,8 +14,6 @@ namespace Qobo\Utils\ModuleConfig\Parser;
 use Cake\Core\InstanceConfigTrait;
 use InvalidArgumentException;
 use JsonSchema\Constraints\Constraint;
-use JsonSchema\Constraints\Factory;
-use JsonSchema\Exception\ValidationException;
 use JsonSchema\Validator;
 use Qobo\Utils\ConfigInterface;
 use Qobo\Utils\ErrorTrait;

--- a/src/ModuleConfig/Parser/Parser.php
+++ b/src/ModuleConfig/Parser/Parser.php
@@ -17,6 +17,7 @@ use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
 use JsonSchema\Exception\ValidationException;
 use JsonSchema\Validator;
+use Qobo\Utils\ConfigInterface;
 use Qobo\Utils\ErrorTrait;
 use Qobo\Utils\ModuleConfig\Parser\SchemaInterface;
 use Qobo\Utils\Utility;
@@ -24,7 +25,7 @@ use Qobo\Utils\Utility\Convert;
 use Seld\JsonLint\ParsingException;
 use stdClass;
 
-class Parser implements ParserInterface
+class Parser implements ConfigInterface, ParserInterface
 {
     use ErrorTrait;
     use InstanceConfigTrait;

--- a/src/ModuleConfig/Parser/ParserInterface.php
+++ b/src/ModuleConfig/Parser/ParserInterface.php
@@ -11,7 +11,6 @@
  */
 namespace Qobo\Utils\ModuleConfig\Parser;
 
-use InvalidArgumentException;
 use Qobo\Utils\ErrorAwareInterface;
 use \stdClass;
 

--- a/src/ModuleConfig/Parser/Schema.php
+++ b/src/ModuleConfig/Parser/Schema.php
@@ -133,7 +133,6 @@ class Schema implements SchemaInterface
             }
 
             if ($result !== false) {
-                /** @var array */
                 return Convert::arrayToObject($result);
             }
         }

--- a/src/ModuleConfig/Parser/Schema.php
+++ b/src/ModuleConfig/Parser/Schema.php
@@ -15,7 +15,6 @@ use Cake\Core\InstanceConfigTrait;
 use InvalidArgumentException;
 use Qobo\Utils\Utility;
 use Qobo\Utils\Utility\Convert;
-use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
 use stdClass;
 

--- a/src/ModuleConfig/Parser/SchemaInterface.php
+++ b/src/ModuleConfig/Parser/SchemaInterface.php
@@ -11,7 +11,6 @@
  */
 namespace Qobo\Utils\ModuleConfig\Parser;
 
-use \InvalidArgumentException;
 use \stdClass;
 
 interface SchemaInterface

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -21,7 +21,6 @@ use Cake\Filesystem\Folder;
 use Cake\Utility\Inflector;
 use DirectoryIterator;
 use InvalidArgumentException;
-use stdClass;
 use UnexpectedValueException;
 
 class Utility

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -6,7 +6,9 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior;
+use Qobo\Utils\Test\App\Model\Table\UsersTable;
 use RuntimeException;
+use Webmozart\Assert\Assert;
 
 /**
  * Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior Test Case
@@ -54,8 +56,9 @@ class EncryptedFieldsBehaviorTest extends TestCase
         parent::setUp();
 
         $this->key = Configure::readOrFail('Qobo/Utils.encryptionKey');
-        /** @var \Qobo\Utils\Test\App\Model\Table\UsersTable $table */
         $table = TableRegistry::getTableLocator()->get('Users');
+        Assert::isInstanceOf($table, UsersTable::class);
+
         $this->Users = $table;
         $this->Users->setTable('users');
 

--- a/tests/TestCase/ModuleConfig/Parser/ParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/ParserTest.php
@@ -3,13 +3,13 @@ namespace Qobo\Utils\Test\TestCase\ModuleConfig\Parser;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
-
 use PHPUnit\Framework\TestCase;
 use Qobo\Utils\ModuleConfig\Parser\Parser;
 use Qobo\Utils\ModuleConfig\Parser\Schema;
 use Qobo\Utils\ModuleConfig\Parser\SchemaInterface;
 use Qobo\Utils\Utility\Convert;
 use stdClass;
+use Webmozart\Assert\Assert;
 
 class ParserTest extends TestCase
 {
@@ -180,7 +180,6 @@ class ParserTest extends TestCase
      */
     public function testParseSkipEmptyData(): void
     {
-        /** @var \Qobo\Utils\ModuleConfig\Parser\SchemaInterface */
         $schema = $this->getEmptySchema();
         $parser = new Parser($schema);
         $parser->parse($this->getFile('sample_empty'));
@@ -194,7 +193,6 @@ class ParserTest extends TestCase
      */
     public function testParseSkipEmptySchema(): void
     {
-        /** @var \Qobo\Utils\ModuleConfig\Parser\SchemaInterface $schema */
         $schema = $this->getEmptySchema();
         $parser = new Parser($schema);
         $parser->parse($this->getFile('sample'));
@@ -210,7 +208,6 @@ class ParserTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        /** @var \Qobo\Utils\ModuleConfig\Parser\SchemaInterface $schema */
         $schema = $this->getEmptySchema();
         $parser = new Parser($schema, [
             'allowEmptyData' => false,
@@ -229,7 +226,6 @@ class ParserTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        /** @var \Qobo\Utils\ModuleConfig\Parser\SchemaInterface $schema */
         $schema = $this->getEmptySchema();
         $parser = new Parser($schema, [
             'allowEmptyData' => false,
@@ -253,12 +249,13 @@ class ParserTest extends TestCase
     /**
      * Returns a mock of SchemaInterface.
      *
-     * @return \PHPUnit\Framework\MockObject\MockObject Schema mock
+     * @return \Qobo\Utils\ModuleConfig\Parser\SchemaInterface Schema mock
      */
-    protected function getEmptySchema(): MockObject
+    protected function getEmptySchema(): SchemaInterface
     {
         $schemaMock = $this->getMockBuilder(SchemaInterface::class)->getMock();
         $schemaMock->method('read')->willReturn(new stdClass);
+        Assert::isInstanceOf($schemaMock, SchemaInterface::class);
 
         return $schemaMock;
     }


### PR DESCRIPTION
This PR introduces the assertions library while also improves the type hints and checks, mostly by not relying on var annotations. In particular:

* Introduces `ConfigInterface` to be used along with `InstanceConfigTrait` 
* Removes invalid var annotations and unnecessary castings
* Applies more strict type-hints whenever this was possible
