### PR TITLE
Add helper methods for testing modules (task #9677)

### DIFF
--- a/src/ModuleConfig/ModuleConfig.php
+++ b/src/ModuleConfig/ModuleConfig.php
@@ -308,4 +308,44 @@ class ModuleConfig implements ErrorAwareInterface
 
         $this->errors[] = "Cannot merge messages from [" . get_class($source) . "]";
     }
+
+    /**
+     * Checks if the provided module name exists
+     *
+     * @param string $moduleName Module name
+     * @param mixed[] $options Options for ModuleConfig constructor
+     * @return bool
+     */
+    public static function exists(string $moduleName, array $options = []) : bool
+    {
+        $config = (new ModuleConfig(ConfigType::MIGRATION(), $moduleName, null, $options))->parseToArray();
+        if (empty($config)) {
+            return false;
+        }
+
+        $config = (new ModuleConfig(ConfigType::MODULE(), $moduleName, null, $options))->parseToArray();
+        if (empty($config['table']) || empty($config['table']['type'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks whether the provided fields exists in migration configuration
+     *
+     * @param string $moduleName Module name
+     * @param mixed[] $fields List of fields to be checked
+     * @param mixed[] $options Options for ModuleConfig constructor
+     * @return bool
+     */
+    public static function hasMigrationFields(string $moduleName, array $fields, array $options = []): bool
+    {
+        $config = (new ModuleConfig(ConfigType::MIGRATION(), $moduleName, null, $options))->parseToArray();
+
+        $fieldKeys = array_flip($fields);
+        $diff = array_diff_key($fieldKeys, $config);
+
+        return empty($diff);
+    }
 }

--- a/tests/TestCase/ModuleConfig/ModuleConfigTest.php
+++ b/tests/TestCase/ModuleConfig/ModuleConfigTest.php
@@ -214,4 +214,18 @@ class ModuleConfigTest extends TestCase
 
         $this->assertSame($parser, $mc->getParser());
     }
+
+    public function testExists(): void
+    {
+        $this->assertTrue(ModuleConfig::exists('Foo'));
+        $this->assertFalse(ModuleConfig::exists('Boo'));
+    }
+
+    public function testHasMigrationFields(): void
+    {
+        $this->assertTrue(ModuleConfig::hasMigrationFields('Foo', []));
+        $this->assertTrue(ModuleConfig::hasMigrationFields('Foo', ['id', 'name', 'description']));
+        $this->assertFalse(ModuleConfig::hasMigrationFields('Foo', ['id', 'name', 'unknown']));
+        $this->assertFalse(ModuleConfig::hasMigrationFields('Foo', ['unknown']));
+    }
 }


### PR DESCRIPTION
Add helper methods on ModuleConfig class which can be used to evaluate whether a module exists or has some particular migration fields. 