### PR TITLE
Implement encrypted fields behavior (task #9585)

### DIFF
--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -11,7 +11,26 @@ use Cake\Utility\Security;
 use RuntimeException;
 
 /**
- * EncryptedFields behavior
+ * Encrypted Fields Behavior.
+ *
+ * Allows to encrypt specified columns in `Model.beforeSave` event. Provides methods
+ * to decrypt columns via a custom finder, which internally uses map/reduce.
+ * Encryption and decryption is done via native Cake class {@link \Cake\Utility\Security}.
+ *
+ * Encrypt columns by attaching the behavior:
+ *
+ * ```php
+ * $this->addBehavior('Qobo/Social.EncryptedColumn', [
+ *     'enabled' => true,
+ *     'encryptionKey' => Configure::readOrFail('App.customEncryptionKey'),
+ *     'fields' => [
+ *         'credit_card',
+ *     ]
+ * ]);
+ * ```
+ *
+ * Decryption is provided via custom finder and other public methods which can be used
+ * directly on entities.
  */
 class EncryptedFieldsBehavior extends Behavior
 {

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -138,6 +138,9 @@ class EncryptedFieldsBehavior extends Behavior
     /**
      * Encrypts the fields.
      *
+     * If the value of the fields is null or a resource the encryption process
+     * if skipped for this field.
+     *
      * @param \Cake\Datasource\EntityInterface $entity Entity object.
      * @return \Cake\Datasource\EntityInterface Entity object.
      */
@@ -158,7 +161,7 @@ class EncryptedFieldsBehavior extends Behavior
                 continue;
             }
             $value = $entity->get($name);
-            if ($value === null) {
+            if ($value === null || is_resource($value)) {
                 continue;
             }
             $encrypted = Security::encrypt($value, $encryptionKey);

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -116,14 +116,10 @@ class EncryptedFieldsBehavior extends Behavior
 
         $mapper = function (EntityInterface $entity, $key, MapReduce $mapReduce) use ($fields) {
             $entity = $this->decryptEntity($entity, $fields);
-            $mapReduce->emitIntermediate($entity, $key);
+            $mapReduce->emit($entity);
         };
 
-        $reducer = function ($accounts, $key, MapReduce $mapReduce) {
-            $mapReduce->emit($accounts, $key);
-        };
-
-        return $query->mapReduce($mapper, $reducer);
+        return $query->mapReduce($mapper);
     }
 
     /**

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -162,6 +162,9 @@ class EncryptedFieldsBehavior extends Behavior
                 continue;
             }
             $value = $entity->get($name);
+            if ($value === null) {
+                continue;
+            }
             $encrypted = Security::encrypt($value, $encryptionKey);
             if ($base64 === true) {
                 $encrypted = base64_encode($encrypted);

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -132,7 +132,7 @@ class EncryptedFieldsBehavior extends Behavior
      */
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
-        $entity = $this->encrypt($entity);
+        $entity = $this->encryptEntity($entity);
     }
 
     /**
@@ -141,7 +141,7 @@ class EncryptedFieldsBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity Entity object.
      * @return \Cake\Datasource\EntityInterface Entity object.
      */
-    public function encrypt(EntityInterface $entity): EntityInterface
+    public function encryptEntity(EntityInterface $entity): EntityInterface
     {
         if (!$this->isEncryptable($entity)) {
             return $entity;

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -244,9 +244,12 @@ class EncryptedFieldsBehavior extends Behavior
             $encryptionKey = $this->getConfig('encryptionKey');
             $base64 = $this->getConfig('base64');
             $encoded = $entity->get($field);
-            if (!empty($encoded)) {
+            if (!empty($encoded) && $encoded !== false) {
                 if ($base64 === true) {
                     $encoded = base64_decode($encoded, true);
+                    if ($encoded === false) {
+                        return null;
+                    }
                 }
                 $decrypted = Security::decrypt($encoded, $encryptionKey);
                 if ($decrypted === false) {

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -20,7 +20,7 @@ use RuntimeException;
  * Encrypt columns by attaching the behavior:
  *
  * ```php
- * $this->addBehavior('Qobo/Social.EncryptedColumn', [
+ * $this->addBehavior('Qobo/Utils.EncryptedColumn', [
  *     'enabled' => true,
  *     'encryptionKey' => Configure::readOrFail('App.customEncryptionKey'),
  *     'fields' => [

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -123,7 +123,7 @@ class EncryptedFieldsBehavior extends Behavior
     }
 
     /**
-     * Callback to never really delete a record but instead mark it as `trashed`.
+     * `Modele.beforeSave` callback which runs the entity encryption.
      *
      * @param \Cake\Event\Event $event The beforeDelete event that was fired.
      * @param \Cake\Datasource\EntityInterface $entity The entity to be deleted.

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -243,20 +243,22 @@ class EncryptedFieldsBehavior extends Behavior
             $encryptionKey = $this->getConfig('encryptionKey');
             $base64 = $this->getConfig('base64');
             $encoded = $entity->get($field);
-            if (!empty($encoded) && $encoded !== false) {
-                if ($base64 === true) {
-                    $encoded = base64_decode($encoded, true);
-                    if ($encoded === false) {
-                        return null;
-                    }
-                }
-                $decrypted = Security::decrypt($encoded, $encryptionKey);
-                if ($decrypted === false) {
-                    throw new RuntimeException("Unable to decypher `{$field}`. Check your enryption key.");
-                }
-
-                return $decrypted;
+            if (empty($encoded) || $encoded === false) {
+                return null;
             }
+
+            if ($base64 === true) {
+                $encoded = base64_decode($encoded, true);
+                if ($encoded === false) {
+                    return null;
+                }
+            }
+            $decrypted = Security::decrypt($encoded, $encryptionKey);
+            if ($decrypted === false) {
+                throw new RuntimeException("Unable to decypher `{$field}`. Check your enryption key.");
+            }
+
+            return $decrypted;
         }
 
         return null;

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -1,6 +1,9 @@
 <?php
 namespace Qobo\Utils\Model\Behavior;
 
+use ArrayObject;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\Event;
 use Cake\ORM\Behavior;
 
 /**
@@ -31,5 +34,29 @@ class EncryptedFieldsBehavior extends Behavior
     public function initialize(array $config)
     {
         $this->setConfig($config);
+    }
+
+    /**
+     * Callback to never really delete a record but instead mark it as `trashed`.
+     *
+     * @param \Cake\Event\Event $event The beforeDelete event that was fired.
+     * @param \Cake\Datasource\EntityInterface $entity The entity to be deleted.
+     * @param \ArrayObject $options Options.
+     * @return void
+     */
+    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options): void
+    {
+        $entity = $this->encrypt($entity);
+    }
+
+    /**
+     * Encrypts the fields.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Entity object.
+     * @return \Cake\Datasource\EntityInterface Entity object.
+     */
+    public function encrypt(EntityInterface $entity): EntityInterface
+    {
+        return $entity;
     }
 }

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -139,7 +139,7 @@ class EncryptedFieldsBehavior extends Behavior
      * Encrypts the fields.
      *
      * If the value of the fields is null or a resource the encryption process
-     * if skipped for this field.
+     * is skipped for this field.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity object.
      * @return \Cake\Datasource\EntityInterface Entity object.
@@ -174,7 +174,7 @@ class EncryptedFieldsBehavior extends Behavior
         if (!empty($patch)) {
             $accessible = array_fill_keys(array_keys($patch), true);
             $entity = $table->patchEntity($entity, $patch, [
-                'accessibleField' => $accessible,
+                'accessibleFields' => $accessible,
             ]);
         }
 

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -69,6 +69,21 @@ class EncryptedFieldsBehavior extends Behavior
      */
     public function initialize(array $config)
     {
+        $encryptionKey = $this->getConfig('encryptionKey');
+        if (!empty($config['encryptionKey'])) {
+            $encryptionKey = $config['encryptionKey'];
+        }
+        if (empty($encryptionKey)) {
+            throw new RuntimeException('Encryption key is required.');
+        }
+
+        $enabled = $this->getConfig('enabled');
+        if (!empty($config['enabled'])) {
+            $enabled = $config['enabled'];
+        }
+        if (!is_callable($enabled) && !is_bool($enabled)) {
+            throw new RuntimeException('Enabled flag must be a boolean or a callable which returns a boolean.');
+        }
         $this->setConfig($config);
     }
 

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -2,7 +2,6 @@
 namespace Qobo\Utils\Model\Behavior;
 
 use Cake\ORM\Behavior;
-use Cake\ORM\Table;
 
 /**
  * EncryptedFields behavior

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -1,0 +1,19 @@
+<?php
+namespace Qobo\Utils\Model\Behavior;
+
+use Cake\ORM\Behavior;
+use Cake\ORM\Table;
+
+/**
+ * EncryptedFields behavior
+ */
+class EncryptedFieldsBehavior extends Behavior
+{
+
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [];
+}

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -240,22 +240,21 @@ class EncryptedFieldsBehavior extends Behavior
      */
     public function decryptEntityField(EntityInterface $entity, string $field)
     {
-        if (!$this->canDecryptField($entity, $field)) {
-            return null;
-        }
-        $encryptionKey = $this->getConfig('encryptionKey');
-        $base64 = $this->getConfig('base64');
-        $encoded = $entity->get($field);
-        if (!empty($encoded)) {
-            if ($base64 === true) {
-                $encoded = base64_decode($encoded, true);
-            }
-            $decrypted = Security::decrypt($encoded, $encryptionKey);
-            if ($decrypted === false) {
-                throw new RuntimeException("Unable to decypher `{$field}`. Check your enryption key.");
-            }
+        if ($this->canDecryptField($entity, $field)) {
+            $encryptionKey = $this->getConfig('encryptionKey');
+            $base64 = $this->getConfig('base64');
+            $encoded = $entity->get($field);
+            if (!empty($encoded)) {
+                if ($base64 === true) {
+                    $encoded = base64_decode($encoded, true);
+                }
+                $decrypted = Security::decrypt($encoded, $encryptionKey);
+                if ($decrypted === false) {
+                    throw new RuntimeException("Unable to decypher `{$field}`. Check your enryption key.");
+                }
 
-            return $decrypted;
+                return $decrypted;
+            }
         }
 
         return null;

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -14,6 +14,19 @@ class EncryptedFieldsBehavior extends Behavior
     /**
      * Default configuration.
      *
+     * - enabled: Boolean or custom callable which returns a boolean and accepts
+     *      {@link \Cake\Datasource\EntityInterface} as a parameter.
+     *      Determines if encryption is enabled for this particular entity.
+     * - encryptionKey: Encryption key. Mandatory if `enabled` is set to `true`.
+     * - fields: Array of fields to encrypt. Each field may be an array of the following settings:
+     *      - decrypt: boolean or callable which accepts {@link \Cake\Datasource\EntityInterface}
+     *          and field name as parameters, and return a boolean, which determines
+     *          if decryption is enabled for this field. Useful for permission checks.
+     * - base64: Whether to encode/decode the encrypted string in base64 so the
+     *      encrypted field can be stored as a string.
+     * - decryptAll: Set to true to allow decrypting all `fields`.
+     *      Overrides the decryption values specified in `fields`.
+     *
      * @var array
      */
     protected $_defaultConfig = [

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -250,10 +250,9 @@ class EncryptedFieldsBehavior extends Behavior
             if ($base64 === true) {
                 $encoded = base64_decode($encoded, true);
             }
-            // $decoded = base64_decode($encoded, true);
             $decrypted = Security::decrypt($encoded, $encryptionKey);
             if ($decrypted === false) {
-                throw new RuntimeException('Unable to decypher credentials. Check your enryption key.');
+                throw new RuntimeException("Unable to decypher `{$field}`. Check your enryption key.");
             }
 
             return $decrypted;

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -276,9 +276,7 @@ class EncryptedFieldsBehavior extends Behavior
             return true;
         }
 
-        $decryptFields = [];
         $fields = $this->getFields();
-
         if (!isset($fields[$field])) {
             return false;
         }

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -9,11 +9,28 @@ use Cake\ORM\Table;
  */
 class EncryptedFieldsBehavior extends Behavior
 {
-
     /**
      * Default configuration.
      *
      * @var array
      */
-    protected $_defaultConfig = [];
+    protected $_defaultConfig = [
+        'enabled' => true,
+        'encryptionKey' => '',
+        'fields' => [
+        ],
+        'base64' => true,
+        'decryptAll' => true,
+    ];
+
+    /**
+     * Initialize the behavior.
+     *
+     * @param array $config The config for this behavior.
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+        $this->setConfig($config);
+    }
 }

--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -296,11 +296,9 @@ class EncryptedFieldsBehavior extends Behavior
     protected function getFields(): array
     {
         $fields = $this->getConfig('fields');
-
         $defaults = [
             'decrypt' => false,
         ];
-
         $result = [];
         foreach ($fields as $field => $values) {
             if (is_numeric($field)) {

--- a/tests/App/Model/Entity/User.php
+++ b/tests/App/Model/Entity/User.php
@@ -1,0 +1,12 @@
+<?php
+namespace Qobo\Utils\Test\App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class User extends Entity
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $_accessible = ['*' => true, 'id' => false];
+}

--- a/tests/App/Model/Table/UsersTable.php
+++ b/tests/App/Model/Table/UsersTable.php
@@ -1,0 +1,14 @@
+<?php
+namespace Qobo\Utils\Test\App\Model\Table;
+
+use Cake\ORM\Table;
+
+class UsersTable extends Table
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize(array $config)
+    {
+    }
+}

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -156,10 +156,9 @@ class EncryptedFieldsBehaviorTest extends TestCase
         $entity = $this->Users->newEntity([
             'name' => $name,
         ]);
-
+        $expected = clone $entity;
         $actualEntity = $this->EncryptedFields->encryptEntity($entity);
-        $this->assertSame($entity, $actualEntity);
-        $this->assertEquals($entity, $actualEntity);
+        $this->assertEquals($expected, $actualEntity);
         $this->assertEquals($name, $actualEntity->get('name'));
     }
 
@@ -196,9 +195,9 @@ class EncryptedFieldsBehaviorTest extends TestCase
         ]);
 
         $entity = $this->Users->newEntity();
+        $expected = clone $entity;
         $actualEntity = $this->EncryptedFields->encryptEntity($entity);
-        $this->assertSame($entity, $actualEntity);
-        $this->assertEquals($entity, $actualEntity);
+        $this->assertEquals($expected, $actualEntity);
     }
 
     /**
@@ -206,7 +205,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testDencryptEntity(): void
+    public function testDecryptEntity(): void
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
@@ -221,7 +220,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testDencryptMissingFieldsAreSkipped(): void
+    public function testDecryptMissingFieldsAreSkipped(): void
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
@@ -238,7 +237,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testDencryptFailure(): void
+    public function testDecryptFailure(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -265,7 +264,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testDencryptEntityWhenDisabled(): void
+    public function testDecryptEntityWhenDisabled(): void
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
@@ -282,7 +281,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testDencryptEntityFieldsCannotBeDecrypted(): void
+    public function testDecryptEntityFieldsCannotBeDecrypted(): void
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace Qobo\Utils\Test\TestCase\Model\Behavior;
+
+use Cake\TestSuite\TestCase;
+use Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior;
+
+/**
+ * Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior Test Case
+ */
+class EncryptedFieldsBehaviorTest extends TestCase
+{
+
+    /**
+     * Test subject
+     *
+     * @var \Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior
+     */
+    public $EncryptedFields;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->EncryptedFields = new EncryptedFieldsBehavior();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->EncryptedFields);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initial setup
+     *
+     * @return void
+     */
+    public function testInitialization()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -156,7 +156,6 @@ class EncryptedFieldsBehaviorTest extends TestCase
     public function testEncryptSuccess(): void
     {
         $name = 'foobar';
-        $encryptedName = Security::encrypt($name, $this->key);
         $entity = $this->Users->newEntity([
             'name' => $name,
         ]);
@@ -164,12 +163,6 @@ class EncryptedFieldsBehaviorTest extends TestCase
         // Assert name was changed
         $actualEntity = $this->EncryptedFields->encrypt($entity);
         $this->assertTrue($actualEntity->isDirty('name'));
-
-        // Decrypt the name and compare
-        $actualName = $actualEntity->get('name');
-        $decodedName = (string)base64_decode($actualName, true);
-        $decryptedName = Security::decrypt($decodedName, $this->key);
-        $this->assertEquals($name, $decryptedName);
     }
 
     /**
@@ -186,10 +179,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
             ]
         ]);
 
-        $name = 'foobar';
-        $encryptedName = Security::encrypt($name, $this->key);
         $entity = $this->Users->newEntity();
-
         $actualEntity = $this->EncryptedFields->encrypt($entity);
         $this->assertSame($entity, $actualEntity);
         $this->assertEquals($entity, $actualEntity);

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Qobo\Utils\Test\TestCase\Model\Behavior;
 
+use Cake\Core\Configure;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior;
 
@@ -11,11 +13,34 @@ class EncryptedFieldsBehaviorTest extends TestCase
 {
 
     /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.qobo/utils.users',
+    ];
+
+    /**
      * Test subject
      *
      * @var \Qobo\Utils\Model\Behavior\EncryptedFieldsBehavior
      */
     public $EncryptedFields;
+
+    /**
+     * Test table
+     *
+     * @var \Qobo\Utils\Test\App\Model\Table\UsersTable
+     */
+    public $Users;
+
+    /**
+     * Encryption key
+     *
+     * @var string
+     */
+    protected $key;
 
     /**
      * setUp method
@@ -25,7 +50,23 @@ class EncryptedFieldsBehaviorTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->EncryptedFields = new EncryptedFieldsBehavior();
+
+        $this->key = Configure::readOrFail('Qobo/Utils.encryptionKey');
+        /** @var \Qobo\Utils\Test\App\Model\Table\UsersTable $table */
+        $table = TableRegistry::getTableLocator()->get('Users');
+        $this->Users = $table;
+        $this->Users->setTable('users');
+
+        $config = [
+            'encryptionKey' => $this->key,
+            'fields' => [
+                'name' => [
+                    'decrypt' => true,
+                ],
+            ],
+        ];
+        $this->EncryptedFields = new EncryptedFieldsBehavior($this->Users, $config);
+        $this->Users->addBehavior('Qobo/Utils.EncryptedFields', $config);
     }
 
     /**
@@ -36,6 +77,8 @@ class EncryptedFieldsBehaviorTest extends TestCase
     public function tearDown()
     {
         unset($this->EncryptedFields);
+        unset($this->key);
+        unset($this->Users);
 
         parent::tearDown();
     }
@@ -45,7 +88,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function testInitialization()
+    public function testInitialization(): void
     {
         $this->markTestIncomplete('Not implemented yet.');
     }

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -398,4 +398,19 @@ class EncryptedFieldsBehaviorTest extends TestCase
         $this->assertTrue($actualEntity->isDirty('name'));
         $this->assertNotEquals($name, $actualEntity->get('name'));
     }
+
+    /**
+     * Test custom finder method when decryption is disabled.
+     *
+     * @return void
+     */
+    public function testDecryptWithEmptyFieldReturnsNull(): void
+    {
+        $name = 'foobar';
+        $entity = $this->Users->newEntity([
+            'name' => '',
+        ]);
+        $actual = $this->EncryptedFields->decryptEntityField($entity, 'name');
+        $this->assertNull($actual);
+    }
 }

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -105,8 +105,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     public function testInitializeEnabledValidationInvalidType(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->EncryptedFields->setConfig(['enabled' => 'foobar']);
-        $this->EncryptedFields->initialize([]);
+        $this->EncryptedFields->initialize(['enabled' => 'foobar']);
     }
 
     /**
@@ -116,8 +115,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
      */
     public function testInitializeEnabledValidationValidType(): void
     {
-        $this->EncryptedFields->setConfig(['enabled' => false]);
-        $this->EncryptedFields->initialize([]);
+        $this->EncryptedFields->initialize(['enabled' => false]);
         $this->assertFalse($this->EncryptedFields->getConfig('enabled'));
 
         $this->EncryptedFields->setConfig(['enabled' => function () {
@@ -172,5 +170,28 @@ class EncryptedFieldsBehaviorTest extends TestCase
         $decodedName = (string)base64_decode($actualName, true);
         $decryptedName = Security::decrypt($decodedName, $this->key);
         $this->assertEquals($name, $decryptedName);
+    }
+
+    /**
+     * Test missing fields are skipped
+     *
+     * @return void
+     */
+    public function testEncryptMissingFieldsAreSkipped(): void
+    {
+        $this->EncryptedFields->setConfig(['fields' => [
+                'invalid_field' => [
+                    'decrypt' => true,
+                ],
+            ]
+        ]);
+
+        $name = 'foobar';
+        $encryptedName = Security::encrypt($name, $this->key);
+        $entity = $this->Users->newEntity();
+
+        $actualEntity = $this->EncryptedFields->encrypt($entity);
+        $this->assertSame($entity, $actualEntity);
+        $this->assertEquals($entity, $actualEntity);
     }
 }

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -379,4 +379,23 @@ class EncryptedFieldsBehaviorTest extends TestCase
         $this->assertEquals('user2', $users[1]->get('name'));
         $this->assertNotEquals($name, $users[2]->get('name'));
     }
+
+    /**
+     * Test custom finder method when decryption is disabled.
+     *
+     * @return void
+     */
+    public function testEncryptWithInaccessibleField(): void
+    {
+        $name = 'foobar';
+        $entity = $this->Users->newEntity([
+            'name' => $name,
+        ]);
+        $entity->setAccess('name', false);
+
+        // Assert name was changed
+        $actualEntity = $this->EncryptedFields->encryptEntity($entity);
+        $this->assertTrue($actualEntity->isDirty('name'));
+        $this->assertNotEquals($name, $actualEntity->get('name'));
+    }
 }

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -157,7 +157,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
             'name' => $name,
         ]);
 
-        $actualEntity = $this->EncryptedFields->encrypt($entity);
+        $actualEntity = $this->EncryptedFields->encryptEntity($entity);
         $this->assertSame($entity, $actualEntity);
         $this->assertEquals($entity, $actualEntity);
         $this->assertEquals($name, $actualEntity->get('name'));
@@ -176,7 +176,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
         ]);
 
         // Assert name was changed
-        $actualEntity = $this->EncryptedFields->encrypt($entity);
+        $actualEntity = $this->EncryptedFields->encryptEntity($entity);
         $this->assertTrue($actualEntity->isDirty('name'));
     }
 
@@ -195,7 +195,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
         ]);
 
         $entity = $this->Users->newEntity();
-        $actualEntity = $this->EncryptedFields->encrypt($entity);
+        $actualEntity = $this->EncryptedFields->encryptEntity($entity);
         $this->assertSame($entity, $actualEntity);
         $this->assertEquals($entity, $actualEntity);
     }
@@ -209,7 +209,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
-        $encrypted = $this->EncryptedFields->encrypt($entity);
+        $encrypted = $this->EncryptedFields->encryptEntity($entity);
 
         $decrypted = $this->EncryptedFields->decryptEntity($encrypted, ['name']);
         $this->assertEquals($name, $decrypted->get('name'));
@@ -224,7 +224,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
-        $encrypted = $this->EncryptedFields->encrypt($entity);
+        $encrypted = $this->EncryptedFields->encryptEntity($entity);
         $decrypted = $this->EncryptedFields->decryptEntity($encrypted, ['missing_field']);
         // No errors should be produced, and `name` should still be encrypted
         $decodedName = (string)base64_decode($decrypted->get('name'));
@@ -243,7 +243,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
 
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
-        $encrypted = $this->EncryptedFields->encrypt($entity);
+        $encrypted = $this->EncryptedFields->encryptEntity($entity);
 
         $this->EncryptedFields->setConfig([
             // Has to be long otherwirse Security class will throw an exception.
@@ -268,7 +268,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
-        $this->EncryptedFields->encrypt($entity);
+        $this->EncryptedFields->encryptEntity($entity);
         $encrypted = clone $entity;
 
         $this->EncryptedFields->setConfig(['enabled' => false]);
@@ -285,7 +285,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
-        $encrypted = $this->EncryptedFields->encrypt($entity);
+        $encrypted = $this->EncryptedFields->encryptEntity($entity);
 
         $this->EncryptedFields->setConfig(
             [
@@ -316,7 +316,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     {
         $name = 'foobar';
         $entity = $this->Users->newEntity(['name' => $name]);
-        $encrypted = $this->EncryptedFields->encrypt($entity);
+        $encrypted = $this->EncryptedFields->encryptEntity($entity);
 
         $this->EncryptedFields->setConfig(
             [

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -178,6 +178,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
         // Assert name was changed
         $actualEntity = $this->EncryptedFields->encryptEntity($entity);
         $this->assertTrue($actualEntity->isDirty('name'));
+        $this->assertNotEquals($name, $actualEntity->get('name'));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -107,6 +107,12 @@ Cake\Core\Configure::load('icons', 'default');
 Cake\Core\Configure::load('colors', 'default');
 Cake\Core\Configure::load('module_config', 'default');
 
+/**
+ * Setup a sample encryption key for {@link \Qobo\Utils\Test\TestCase\Model\Behavior\EncryptedFieldsBehaviorTest}
+ * @link https://book.cakephp.org/3.0/en/core-libraries/security.html#encrypting-and-decrypting-data
+ */
+Configure::write('Qobo/' . $pluginName . '.encryptionKey', 'wt1U5MACWJFTXGenFoZoiLwQGrLgdbHA1');
+
 // Alias AppController to the test App
 class_alias('Qobo\\' . $pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.


### PR DESCRIPTION
Adds an encrypted fields behavior, which allows encrypting/decrypting entity fields using `\Cake\Utility\Security` class.

Has an additional finder method which can return decrypted fields and can be chained with other finders.