### PR TITLE
EncryptFieldsBehavior finder fields bug (task #9585)

### DIFF
--- a/src/Model/Behavior/EncryptedFieldsBehavior.php
+++ b/src/Model/Behavior/EncryptedFieldsBehavior.php
@@ -102,20 +102,21 @@ class EncryptedFieldsBehavior extends Behavior
      */
     public function findDecrypt(Query $query, array $options = [])
     {
-        $fields = $options['decryptFields'] ?? [];
+        $decryptFields = $options['decryptFields'] ?? [];
+        $fields = $this->getFields();
         $decryptAll = $this->getConfig('decryptAll');
 
         // Should we enable decryption of all fields if no fields are given to us?
-        if (empty($fields) && $decryptAll === true) {
-            $fields = $this->getConfig('fields');
+        if (empty($decryptFields) && $decryptAll === true) {
+            $decryptFields = array_keys($fields);
         }
 
-        if (empty($fields)) {
+        if (empty($decryptFields)) {
             return $query;
         }
 
-        $mapper = function (EntityInterface $entity, $key, MapReduce $mapReduce) use ($fields) {
-            $entity = $this->decryptEntity($entity, $fields);
+        $mapper = function (EntityInterface $entity, $key, MapReduce $mapReduce) use ($decryptFields) {
+            $entity = $this->decryptEntity($entity, $decryptFields);
             $mapReduce->emit($entity);
         };
 

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -381,7 +381,7 @@ class EncryptedFieldsBehaviorTest extends TestCase
     }
 
     /**
-     * Test custom finder method when decryption is disabled.
+     * Test custom finder method when decryption is enabled.
      *
      * @return void
      */

--- a/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EncryptedFieldsBehaviorTest.php
@@ -385,6 +385,36 @@ class EncryptedFieldsBehaviorTest extends TestCase
      *
      * @return void
      */
+    public function testFinderWithoutFieldsDecryptAllEnabled(): void
+    {
+        $name = 'foobar';
+        $entity = $this->Users->newEntity(['name' => $name]);
+        $this->Users->save($entity);
+
+        $this->Users->getBehavior('EncryptedFields')->setConfig(
+            [
+                'decryptAll' => true,
+                'fields' => [
+                    'name' => [
+                        'decrypt' => false,
+                    ],
+                ],
+            ]
+        );
+
+        $query = $this->Users->find('decrypt');
+        $this->assertEquals(3, $query->count());
+        $users = $query->toArray();
+        $this->assertEquals('user1', $users[0]->get('name'));
+        $this->assertEquals('user2', $users[1]->get('name'));
+        $this->assertEquals($name, $users[2]->get('name'));
+    }
+
+    /**
+     * Test custom finder method when decryption is disabled.
+     *
+     * @return void
+     */
     public function testEncryptWithInaccessibleField(): void
     {
         $name = 'foobar';


### PR DESCRIPTION
Fixes a rare bug with field names when global decryption is enabled and no fields are passed to the finder. See test case for details.