### PR TITLE
Update json schema for the new charts (task #10422)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,6 @@ parameters:
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort
-    ignoreErrors:
-        - '#^Function geoip_country_code_by_name not found\.$#'
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/ModuleConfig/Parser/Schema/reports.json
+++ b/src/ModuleConfig/Parser/Schema/reports.json
@@ -52,7 +52,7 @@
                     "title": "Report rendering choice",
                     "description": "How the report should be rendered/presented",
                     "type": "string",
-                    "enum": ["barChart", "donutChart", "knobChart", "lineChart", "table"]
+                    "enum": ["barChart", "donutChart", "knobChart", "lineChart", "table", "polarArea", "pieChart", "horizontalBar"]
                 },
                 "y_axis": {
                     "title": "Y-axis column",
@@ -78,6 +78,11 @@
                     "title": "Report value maximum",
                     "description": "A maximum for a single value in basic reports (knob)",
                     "type": "string"
+                },
+                "options": {
+                    "title": "Other options",
+                    "description": "Additional options for the chats",
+                    "type": "object"
                 }
             },
             "additionalProperties": false,

--- a/src/ModuleConfig/PathFinder/BasePathFinder.php
+++ b/src/ModuleConfig/PathFinder/BasePathFinder.php
@@ -150,7 +150,8 @@ abstract class BasePathFinder implements PathFinderInterface
         $postfixIndex = strlen($pathinfo['filename']) - strlen($postfix);
         $isDistributionFile = substr($pathinfo['filename'], $postfixIndex) === $postfix;
         if (!$isDistributionFile) {
-            $path = $pathinfo['filename'] . $postfix . '.' . $pathinfo['extension'];
+            $extension = !empty($pathinfo['extension']) ? '.' . $pathinfo['extension'] : '';
+            $path = $pathinfo['filename'] . $postfix . $extension;
         }
 
         return $path;


### PR DESCRIPTION
The `report.json` support now "polarArea", "pieChart", "horizontalBar" charts, plus we can add more options in the configuration for bar, doughnut, line, polarArea, pie and horizontalBar.