### PR TITLE
Expanding field configurations with fileUploadAdapter (task #11014)

### DIFF
--- a/src/ModuleConfig/Parser/Schema/fields.json
+++ b/src/ModuleConfig/Parser/Schema/fields.json
@@ -102,6 +102,11 @@
                     "title": "Step value",
                     "description": "Define a step value to increase/decrease numeric field",
                     "type": "integer"
+                },
+                "fileUploadAdapter": {
+                    "title": "Upload Adapter",
+                    "description": "Define Upload Adapter for FileStorage plugin",
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/src/ModuleConfig/Parser/Schema/fields.json
+++ b/src/ModuleConfig/Parser/Schema/fields.json
@@ -106,7 +106,8 @@
                 "fileUploadAdapter": {
                     "title": "Upload Adapter",
                     "description": "Define Upload Adapter for FileStorage plugin",
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["Local", "AwsS3", "Dropbox", "AzureBlobStorage", "GoogleCloudStorage"]
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
Following extension to `fields` schema will allow `qobo/cakephp-csv-migrations` to use Cloud adapters (like S3 Buckets) for handling file uploads using `burzum/cakephp-file-storage` plugin.

We allow developers to define which file field will be using Local or S3 file upload adapters in csv modules.