### PR TITLE
Lock version for CakePHP Imagine plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "alt3/cakephp-swagger": "^2.0",
         "arvenil/ninja-mutex": "^0.6",
         "burzum/cakephp-file-storage": "dev-branch-2.0",
-        "burzum/cakephp-imagine-plugin": "3.x-dev",
+        "burzum/cakephp-imagine-plugin": "dev-master#d21baf7378271d536982c8c0867fab3dcfa24cc8",
         "cakedc/users": "^8.0",
         "cakephp/cakephp": "^3.5 <3.7",
         "cakephp/migrations": "^1.7",


### PR DESCRIPTION
The latest changes in CakePHP Imagine plugin have increased the minimum CakePHP version from 3.6 to 3.7.

This PR locks the version to the latest commit to maintain support for CakePHP 3.6