### PR TITLE
Disabling defaults substitution (task #10956)

### DIFF
--- a/src/ModuleConfig/Parser/Parser.php
+++ b/src/ModuleConfig/Parser/Parser.php
@@ -38,7 +38,7 @@ class Parser implements ConfigInterface, ParserInterface
         'allowEmptySchema' => true,
         'lint' => false,
         'validate' => false,
-        'validationMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
+        'validationMode' => Constraint::CHECK_MODE_NORMAL
     ];
 
     /**


### PR DESCRIPTION
* Note: All JSON files will needed to be carefully inspected for potential inconsistencies, due to JSON default issues deriving from the `json-schema` package.

Possible restoration of this functionality should be considered once `v6.0.0` of `json-schema` is released.