### PR TITLE
Caching improvements for ModuleConfig (task #14655)

### DIFF
--- a/config/module_config.php
+++ b/config/module_config.php
@@ -25,6 +25,7 @@ return [
         ]),
         'cacheConfig' => 'default',
         'classMapVersion' => 'V3',
+        'distFilesOnly' => false,
         'classMap' => [
             'V3' => [
                 (string)ConfigType::MIGRATION() => [

--- a/config/module_config.php
+++ b/config/module_config.php
@@ -23,6 +23,7 @@ return [
             dirname(__DIR__),
             'src', 'ModuleConfig', 'Parser', 'Schema',
         ]),
+        'cacheConfig' => 'default',
         'classMapVersion' => 'V3',
         'classMap' => [
             'V3' => [

--- a/src/ModuleConfig/Cache/Cache.php
+++ b/src/ModuleConfig/Cache/Cache.php
@@ -12,6 +12,7 @@
 namespace Qobo\Utils\ModuleConfig\Cache;
 
 use Cake\Cache\Cache as CakeCache;
+use Cake\Core\Configure;
 use InvalidArgumentException;
 use Qobo\Utils\ErrorAwareInterface;
 use Qobo\Utils\ErrorTrait;
@@ -27,11 +28,6 @@ use Qobo\Utils\ErrorTrait;
 class Cache implements ErrorAwareInterface
 {
     use ErrorTrait;
-
-    /**
-     * Name of default CakePHP cache configuration
-     */
-    const DEFAULT_CONFIG = 'default';
 
     /**
      * Name of the current cache instance
@@ -115,7 +111,7 @@ class Cache implements ErrorAwareInterface
     protected function setOptions(array $options = []): void
     {
         $this->options = $options;
-        $this->configName = empty($options['cacheConfig']) ? static::DEFAULT_CONFIG : (string)$options['cacheConfig'];
+        $this->configName = empty($options['cacheConfig']) ? (string)Configure::read('ModuleConfig.cacheConfig') : (string)$options['cacheConfig'];
         $this->skipCache = empty($this->options['cacheSkip']) ? false : (bool)$this->options['cacheSkip'];
     }
 

--- a/src/ModuleConfig/PathFinder/BasePathFinder.php
+++ b/src/ModuleConfig/PathFinder/BasePathFinder.php
@@ -61,6 +61,7 @@ abstract class BasePathFinder implements PathFinderInterface
         // Ignore non-distribution files
         if (Configure::read('ModuleConfig.distFilesOnly') && !$this->isDistributionFilePath($path)) {
             $distributionPath = $this->getDistributionFilePath($path);
+
             return $this->find($module, $distributionPath, $validate);
         }
 

--- a/src/ModuleConfig/PathFinder/BasePathFinder.php
+++ b/src/ModuleConfig/PathFinder/BasePathFinder.php
@@ -56,9 +56,15 @@ abstract class BasePathFinder implements PathFinderInterface
      */
     public function find(string $module, string $path = '', bool $validate = true)
     {
-        $this->validateModule($module);
-
         $path = $this->getFilePath($path);
+
+        // Ignore non-distribution files
+        if (Configure::read('ModuleConfig.distFilesOnly') && !$this->isDistributionFilePath($path)) {
+            $distributionPath = $this->getDistributionFilePath($path);
+            return $this->find($module, $distributionPath, $validate);
+        }
+
+        $this->validateModule($module);
         $this->validatePath($path);
 
         $result = '';

--- a/tests/TestCase/ModuleConfig/Cache/CacheTest.php
+++ b/tests/TestCase/ModuleConfig/Cache/CacheTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Qobo\Utils\Test\TestCase\ModuleConfig\Cache;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Qobo\Utils\ModuleConfig\Cache\Cache;
 
@@ -22,7 +23,7 @@ class CacheTest extends TestCase
 
     public function testGetConfig(): void
     {
-        $expected = Cache::DEFAULT_CONFIG;
+        $expected = Configure::read('ModuleConfig.cacheConfig');
         $cache = new Cache('test_cache');
         $result = $cache->getConfig();
         $this->assertEquals($expected, $result, "getConfig() returned a non-default config name: $result");

--- a/tests/config/module_config.php
+++ b/tests/config/module_config.php
@@ -23,6 +23,7 @@ return [
             ROOT,
             'src', 'ModuleConfig', 'Parser', 'Schema',
         ]),
+        'cacheConfig' => 'default',
         'classMapVersion' => 'V3',
         'classMap' => [
             'V3' => [


### PR DESCRIPTION
Caching engine can now be configured on app level. It is also possible to completely disable the file lookup for non dist files, to avoid un-necessary actions when only dist files are in use.