### PR TITLE
Generate php modules from json files (task #16415)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 vendor/
 tmp/
 cghooks.lock
+tests/App/Module/
 
 composer.lock
 config/Migrations/schema-dump-default.lock

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -39,6 +39,7 @@
     <!-- Exclude patterns -->
     <exclude-pattern>config/Migrations/*</exclude-pattern>
     <exclude-pattern>config/Seeds/*</exclude-pattern>
+    <exclude-pattern>tests/App/Module/*</exclude-pattern>
     <exclude-pattern>webroot/plugins/*</exclude-pattern>
     <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,8 @@ parameters:
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort
+    excludes_analyse:
+        - tests/App/Module/FooModule.php
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/Module/Exception/InvalidClassException.php
+++ b/src/Module/Exception/InvalidClassException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Module\Exception;
+
+use RuntimeException;
+
+class InvalidClassException extends RuntimeException
+{
+}

--- a/src/Module/Exception/MissingModuleException.php
+++ b/src/Module/Exception/MissingModuleException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Module\Exception;
+
+use RuntimeException;
+
+class MissingModuleException extends RuntimeException
+{
+}

--- a/src/Module/Module.php
+++ b/src/Module/Module.php
@@ -90,6 +90,14 @@ class Module implements ModuleInterface
     /**
      * {@inheritDoc}
      */
+    public function getMenus(): array
+    {
+        return $this->menus;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getMenu(string $name): array
     {
         if (!isset($this->menus[$name])) {

--- a/src/Module/Module.php
+++ b/src/Module/Module.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Module;
+
+use Cake\Utility\Hash;
+
+class Module implements ModuleInterface
+{
+    /**
+     * Config
+     * @var mixed[]
+     */
+    protected $config;
+
+    /**
+     * Migration
+     * @var mixed[]
+     */
+    protected $migration;
+
+    /**
+     * Fields
+     * @var mixed[]
+     */
+    protected $fields;
+
+    /**
+     * Lists, indexed by list name.
+     * @var mixed[]
+     */
+    protected $lists;
+
+    /**
+     * Menus, indexed by menu name.
+     * @var mixed[]
+     */
+    protected $menus;
+
+    /**
+     * Views, indexed by view name.
+     * @var mixed[]
+     */
+    protected $views;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfig(string $path = ''): array
+    {
+        if (!empty($path)) {
+            return (array)Hash::extract($this->config, $path);
+        }
+
+        return $this->config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMigration(string $path = ''): array
+    {
+        if (!empty($path)) {
+            return (array)Hash::extract($this->migration, $path);
+        }
+
+        return $this->migration;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFields(string $path = ''): array
+    {
+        if (!empty($path)) {
+            return (array)Hash::extract($this->fields, $path);
+        }
+
+        return $this->fields;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMenu(string $name): array
+    {
+        if (!isset($this->menus[$name])) {
+            return [];
+        }
+
+        return $this->menus[$name];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getList(string $name, bool $flatten = false, bool $filter = false): array
+    {
+        if (!isset($this->lists[$name])) {
+            return [];
+        }
+
+        $list = $this->lists[$name];
+        if ($flatten) {
+            $list = $this->flattenList($list);
+        }
+        if ($filter) {
+            $list = $this->filterList($list);
+        }
+
+        return $list;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getView(string $name): array
+    {
+        if (!isset($this->views[$name])) {
+            return [];
+        }
+
+        return $this->views[$name];
+    }
+
+    /**
+     * Method that filters list options, excluding non-active ones
+     *
+     * @param  mixed[]  $data list options
+     * @return mixed[]
+     */
+    protected function filterList(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            if ($value['inactive']) {
+                continue;
+            }
+
+            $result[$key] = $value;
+            if (isset($value['children'])) {
+                $result[$key]['children'] = $this->filterList($value['children']);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Flatten list options.
+     *
+     * @param mixed[] $data List options
+     * @return mixed[]
+     */
+    protected function flattenList(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $item = [
+                'label' => $value['label'],
+                'inactive' => $value['inactive'],
+            ];
+
+            $result[$key] = $item;
+
+            if (isset($value['children'])) {
+                $result = array_merge($result, $this->flattenList($value['children']));
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Module/ModuleInterface.php
+++ b/src/Module/ModuleInterface.php
@@ -46,6 +46,13 @@ interface ModuleInterface
     public function getMenu(string $name): array;
 
     /**
+     * Returns all the module menus.
+     *
+     * @return mixed[]
+     */
+    public function getMenus(): array;
+
+    /**
      * Returns the full contents of the list or a subset specifiec by path.
      *
      * @param string $name List name.

--- a/src/Module/ModuleInterface.php
+++ b/src/Module/ModuleInterface.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Module;
+
+interface ModuleInterface
+{
+    /**
+     * Returns the module config.
+     *
+     * @param string $path Optional path to extract.
+     * @return mixed[]
+     */
+    public function getConfig(string $path = ''): array;
+
+    /**
+     * Returns the module migration.
+     *
+     * @param string $path Optional path to extract.
+     * @return mixed[]
+     */
+    public function getMigration(string $path = ''): array;
+
+    /**
+     * Returns the module fields config.
+     *
+     * @param string $path Optional path to extract.
+     * @return mixed[]
+     */
+    public function getFields(string $path = ''): array;
+
+    /**
+     * Returns the module menus config.
+     *
+     * @param string $name Menu name.
+     * @return mixed[]
+     */
+    public function getMenu(string $name): array;
+
+    /**
+     * Returns the full contents of the list or a subset specifiec by path.
+     *
+     * @param string $name List name.
+     * @param bool $filter Filter the list.
+     * @param bool $flatten Flatten the list.
+     * @return mixed[]
+     */
+    public function getList(string $name, bool $filter = false, bool $flatten = false): array;
+
+    /**
+     * Returns a module view.
+     *
+     * @param string $name View name.
+     * @return mixed[]
+     */
+    public function getView(string $name): array;
+}

--- a/src/Module/ModuleRegistry.php
+++ b/src/Module/ModuleRegistry.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Module;
+
+use Cake\Core\App;
+use Cake\Core\ObjectRegistry;
+use InvalidArgumentException;
+use Webmozart\Assert\Assert;
+
+class ModuleRegistry extends ObjectRegistry
+{
+    /**
+     * Singleton instance.
+     * @var \Qobo\Utils\Module\ModuleRegistry|null
+     */
+    private static $instance;
+
+    /**
+     * Private constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Protect from cloning.
+     *
+     * @return void
+     */
+    private function __clone()
+    {
+    }
+
+    /**
+     * Protect from serialization.
+     *
+     * @return void
+     */
+    private function __wakeup()
+    {
+    }
+
+    /**
+     * Returns a singleton instance of ModuleRegistry.
+     *
+     * @return \Qobo\Utils\Module\ModuleRegistry
+     */
+    public static function instance(): ModuleRegistry
+    {
+        if (!(static::$instance instanceof self)) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    /**
+     * Returns an instance of a given module.
+     *
+     * @param string $moduleName Name of module.
+     * @param mixed[] $config Additional settings to use when loading the object.
+     * @return \Qobo\Utils\Module\ModuleInterface
+     */
+    public static function getModule(string $moduleName, array $config = []): ModuleInterface
+    {
+        $module = self::instance()->get($moduleName);
+        if ($module === null) {
+            $module = self::instance()->load($moduleName, $config);
+        }
+        Assert::isInstanceOf($module, ModuleInterface::class, (string)__d('Qobo/Utils', 'Module `{0}` is not an instance of `{1}`', $moduleName, ModuleInterface::class));
+
+        return $module;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _create($class, $alias, $config)
+    {
+        $instance = new $class();
+
+        return $instance;
+    }
+
+    /**
+     * Resolve a state machine class name.
+     *
+     * @param string $class Partial classname to resolve.
+     * @return string|null Either the correct classname or null.
+     */
+    public static function className(string $class): ?string
+    {
+        $result = App::className($class, 'Module', 'Module');
+
+        return $result ?: null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _resolveClassName($class)
+    {
+        return static::className($class) ?: false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function _throwMissingClassError($class, $plugin)
+    {
+        throw new InvalidArgumentException((string)__d('Qobo/Utils', 'Module `{0}` does not exist.', $class));
+    }
+}

--- a/src/Module/ModuleRegistry.php
+++ b/src/Module/ModuleRegistry.php
@@ -13,8 +13,8 @@ namespace Qobo\Utils\Module;
 
 use Cake\Core\App;
 use Cake\Core\ObjectRegistry;
-use InvalidArgumentException;
-use Webmozart\Assert\Assert;
+use Qobo\Utils\Module\Exception\InvalidClassException;
+use Qobo\Utils\Module\Exception\MissingModuleException;
 
 class ModuleRegistry extends ObjectRegistry
 {
@@ -76,7 +76,9 @@ class ModuleRegistry extends ObjectRegistry
         if ($module === null) {
             $module = self::instance()->load($moduleName, $config);
         }
-        Assert::isInstanceOf($module, ModuleInterface::class, (string)__d('Qobo/Utils', 'Module `{0}` is not an instance of `{1}`', $moduleName, ModuleInterface::class));
+        if (!($module instanceof ModuleInterface)) {
+            throw new InvalidClassException((string)__d('Qobo/Utils', 'Module `{0}` is not an instance of `{1}`', $moduleName, ModuleInterface::class));
+        }
 
         return $module;
     }
@@ -117,6 +119,6 @@ class ModuleRegistry extends ObjectRegistry
      */
     protected function _throwMissingClassError($class, $plugin)
     {
-        throw new InvalidArgumentException((string)__d('Qobo/Utils', 'Module `{0}` does not exist.', $class));
+        throw new MissingModuleException((string)__d('Qobo/Utils', 'Module `{0}` does not exist.', $class));
     }
 }

--- a/src/Shell/GenerateModulesShell.php
+++ b/src/Shell/GenerateModulesShell.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Shell;
+
+use Cake\Console\Shell;
+use Cake\Filesystem\Folder;
+use Webmozart\Assert\Assert;
+
+/**
+ * Generates module classes from json definitions.
+ *
+ * @property \Qobo\Utils\Shell\Task\ModuleTask $Module
+ */
+class GenerateModulesShell extends Shell
+{
+    public $tasks = ['Qobo/Utils.Module'];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        parent::initialize();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->addSubcommand('Module', [
+            'help' => $this->Module->getOptionParser()->getDescription(),
+            'parser' => $this->Module->getOptionParser(),
+        ])->addOption('force', [
+            'short' => 'f',
+            'boolean' => true,
+            'help' => 'Force overwriting existing files without prompting.',
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * Shell entry point
+     *
+     * @return int|bool|null
+     */
+    public function main()
+    {
+        $modules = $this->getModules();
+
+        foreach ($modules as $module) {
+            $this->info(sprintf('Generate module %s', $module));
+
+            $this->Module->main($module);
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieves all module names.
+     *
+     * @return string[]
+     */
+    private function getModules(): array
+    {
+        $dir = new Folder(CONFIG . 'Modules' . DS);
+
+        $result = $dir->read(true);
+        Assert::isArray($result);
+        Assert::notEmpty($result[0]); // hold the directories
+        Assert::isArray($result[0]);
+
+        return $result[0];
+    }
+}

--- a/src/Shell/Task/ModuleTask.php
+++ b/src/Shell/Task/ModuleTask.php
@@ -68,7 +68,10 @@ class ModuleTask extends SimpleBakeTask
      */
     public function main($name = null)
     {
-        Assert::string($name);
+        if (empty($name)) {
+            $this->abort('Missing the required `name` parameter.');
+        }
+
         $this->moduleName = $name;
         parent::main($name);
     }

--- a/src/Shell/Task/ModuleTask.php
+++ b/src/Shell/Task/ModuleTask.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Qobo\Utils\Shell\Task;
+
+use Bake\Shell\Task\SimpleBakeTask;
+use Cake\Filesystem\Folder;
+use Qobo\Utils\ModuleConfig\ConfigType;
+use Qobo\Utils\ModuleConfig\ModuleConfig;
+use Webmozart\Assert\Assert;
+
+class ModuleTask extends SimpleBakeTask
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $pathFragment = 'Module/';
+
+    /**
+     * Module name
+     * @var string
+     */
+    protected $moduleName;
+
+    /**
+     * Options for ModuleConfig.
+     *
+     * @var mixed[]
+     */
+    protected $moduleConfigOptions = [
+        'cacheSkip' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function name()
+    {
+        return 'module';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fileName($name)
+    {
+        return $name . 'Module.php';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function template()
+    {
+        return 'Qobo/Utils.module';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function main($name = null)
+    {
+        Assert::string($name);
+        $this->moduleName = $name;
+        parent::main($name);
+    }
+
+    /**
+     * Get template data.
+     *
+     * @return array
+     */
+    public function templateData()
+    {
+        $config = (new ModuleConfig(ConfigType::MODULE(), $this->moduleName, null, $this->moduleConfigOptions))->parseToArray();
+        $migration = (new ModuleConfig(ConfigType::MIGRATION(), $this->moduleName, null, $this->moduleConfigOptions))->parseToArray();
+        $lists = $this->getModuleLists();
+        $fields = (new ModuleConfig(ConfigType::FIELDS(), $this->moduleName, null, $this->moduleConfigOptions))->parseToArray();
+        $menus = (new ModuleConfig(ConfigType::MENUS(), $this->moduleName, null, $this->moduleConfigOptions))->parseToArray();
+        $views = $this->getModuleViews();
+
+        $config = var_export($config, true);
+        $migration = var_export($migration, true);
+        $lists = var_export($lists, true);
+        $fields = var_export($fields, true);
+        $menus = var_export($menus, true);
+        $views = var_export($views, true);
+
+        return parent::templateData() + compact('config', 'migration', 'lists', 'fields', 'menus', 'views');
+    }
+
+    /**
+     * Returns an array of all lists of the module and their respective contents.
+     *
+     * @return mixed[]
+     */
+    protected function getModuleLists(): array
+    {
+        $files = $this->getDistinctFiles('lists');
+        if (empty($files)) {
+            return [];
+        }
+
+        $results = [];
+        foreach ($files as $file) {
+            $contents = (new ModuleConfig(ConfigType::LISTS(), $this->moduleName, $file, $this->moduleConfigOptions))->parseToArray();
+            $results[$file] = $contents['items'] ?? [];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Returns an array of all module views and their respective contents.
+     *
+     * @return mixed[]
+     */
+    protected function getModuleViews(): array
+    {
+        $views = $this->getDistinctFiles('views');
+        if (empty($views)) {
+            return [];
+        }
+
+        $results = [];
+        foreach ($views as $file) {
+            $contents = (new ModuleConfig(ConfigType::VIEW(), $this->moduleName, $file, $this->moduleConfigOptions))->parseToArray();
+            $results[$file] = $contents['items'] ?? [];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Returns a list of distict file names from folder, based on `.json` suffix.
+     *
+     * This will strip out all `.dist.json` and `.json` files, remove these two suffixes and
+     * return a unique collection of the result.
+     *
+     * @param string $subFolder Which json sub folder to read.
+     * @return string[]
+     */
+    protected function getDistinctFiles(string $subFolder): array
+    {
+        $path = CONFIG . 'Modules' . DS;
+        if (!empty($this->params['module-path'])) {
+            $path = rtrim($this->params['module-path'], DS) . DS;
+        }
+        $path .= $this->moduleName . DS . $subFolder . DS;
+        $dir = new Folder($path);
+        $files = $dir->find('.*\.json');
+
+        $filtered = array_map(function ($value) {
+            $value = preg_replace('/\.dist\.json$/', '', $value);
+            $value = preg_replace('/\.json$/', '', $value);
+
+            return $value;
+        }, $files);
+
+        return array_unique($filtered);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @todo Checks thats the module exists
+     */
+    public function bake($name)
+    {
+        return parent::bake($name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionParser()
+    {
+        $parser = parent::getOptionParser();
+        $parser->addOption('module-path', [
+            'default' => CONFIG . 'Modules' . DS,
+            'help' => 'Override the application path to folder with module json files, which defaults to `config/Modules/`',
+        ]);
+
+        return $parser;
+    }
+}

--- a/src/Template/Bake/module.twig
+++ b/src/Template/Bake/module.twig
@@ -17,9 +17,9 @@ use Qobo\Utils\Module\Module;
 
 final class {{ name }}Module extends Module
 {
-    protected $configData = {{ config|raw }};
+    protected $config = {{ config|raw }};
 
-    protected $migrationData = {{ migration|raw }};
+    protected $migration = {{ migration|raw }};
 
     protected $lists = {{ lists|raw }};
 

--- a/src/Template/Bake/module.twig
+++ b/src/Template/Bake/module.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+#}
+<?php
+namespace {{ namespace|raw }}\Module;
+
+use Qobo\Utils\Module\Module;
+
+final class {{ name }}Module extends Module
+{
+    protected $configData = {{ config|raw }};
+
+    protected $migrationData = {{ migration|raw }};
+
+    protected $lists = {{ lists|raw }};
+
+    protected $fields = {{ fields|raw }};
+
+    protected $menus = {{ menus|raw }};
+
+    protected $views = {{ views|raw }};
+}

--- a/tests/TestCase/ModuleConfig/Parser/ListParserTest.php
+++ b/tests/TestCase/ModuleConfig/Parser/ListParserTest.php
@@ -21,10 +21,7 @@ class ListParserTest extends TestCase
         $schema = new Schema($schemaPath);
 
         $this->parser = new ListParser($schema);
-        $this->dataDir = TESTS . 'data' . DS . 'Modules';
-
-        Configure::write('CsvMigrations.modules.path', $this->dataDir);
-        Configure::write('ModuleConfig.classMapVersion', 'V2');
+        $this->dataDir = Configure::read('CsvMigrations.modules.path');
     }
 
     public function tearDown()

--- a/tests/TestCase/Shell/Task/ModuleTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModuleTaskTest.php
@@ -89,7 +89,7 @@ class ModuleTaskTest extends ConsoleIntegrationTestCase
     public function testMain(): void
     {
         $path = TESTS . 'data' . DS . 'Modules' . DS;
-        $this->exec('generate_modules module Foo -f -n "Qobo\Utils\Test\App\Module" --module-path=' . $path);
+        $this->exec('generate_modules module Foo -f --module-path=' . $path);
         $this->assertOutputContains('<success>');
         $this->assertFileExists(TESTS . 'App' . DS . 'Module' . DS . 'FooModule.php');
     }

--- a/tests/TestCase/Shell/Task/ModuleTaskTest.php
+++ b/tests/TestCase/Shell/Task/ModuleTaskTest.php
@@ -1,0 +1,96 @@
+<?php
+namespace Qobo\Utils\Test\TestCase\Shell\Task;
+
+use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Qobo\Utils\Shell\Task\ModuleTask;
+
+/**
+ * Qobo\Utils\Shell\Task\ModuleTask Test Case
+ */
+class ModuleTaskTest extends ConsoleIntegrationTestCase
+{
+
+    /**
+     * ConsoleIo mock
+     *
+     * @var \Cake\Console\ConsoleIo|null
+     */
+    public $io;
+
+    /**
+     * Test subject
+     *
+     * @var \Qobo\Utils\Shell\Task\ModuleTask
+     */
+    public $ModuleTask;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        /** @var \Cake\Console\ConsoleIo|null */
+        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
+        $this->io = $io;
+        $this->ModuleTask = new ModuleTask($this->io);
+        $this->useCommandRunner();
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        unset($this->ModuleTask);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test name method
+     *
+     * @return void
+     */
+    public function testName(): void
+    {
+        $this->assertEquals('module', $this->ModuleTask->name());
+    }
+
+    /**
+     * Test fileName method
+     *
+     * @return void
+     */
+    public function testFileName(): void
+    {
+        $this->assertEquals('ThingsModule.php', $this->ModuleTask->fileName('Things'));
+    }
+
+    /**
+     * Test template method
+     *
+     * @return void
+     */
+    public function testTemplate(): void
+    {
+        $this->assertEquals('Qobo/Utils.module', $this->ModuleTask->template());
+    }
+
+    /**
+     * Test main method
+     *
+     * @return void
+     */
+    public function testMain(): void
+    {
+        $path = TESTS . 'data' . DS . 'Modules' . DS;
+        $this->exec('generate_modules module Foo -f -n "Qobo\Utils\Test\App\Module" --module-path=' . $path);
+        $this->assertOutputContains('<success>');
+        $this->assertFileExists(TESTS . 'App' . DS . 'Module' . DS . 'FooModule.php');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,7 @@ require ROOT . '/vendor/autoload.php';
 require CORE_PATH . 'config/bootstrap.php';
 
 Configure::write('App', [
+    'encoding' => 'UTF-8',
     'namespace' => 'Qobo\\' . $pluginName . '\Test\App',
     'paths' => [
         'templates' => [
@@ -53,6 +54,9 @@ Configure::write('App', [
         ],
     ],
 ]);
+Configure::write('CsvMigrations.modules.path', TESTS . 'data' . DS . 'Modules' . DS);
+Configure::write('ModuleConfig.classMapVersion', 'V3');
+
 Configure::write('debug', true);
 
 $TMP = new Folder(TMP);


### PR DESCRIPTION
Generating php classes from json files allows us to generate modules during deployment and avoid reading/parsing json hundreds of times per script execution on production environments