### PR TITLE
Adding limits field property

### DIFF
--- a/src/ModuleConfig/Parser/Schema/fields.json
+++ b/src/ModuleConfig/Parser/Schema/fields.json
@@ -58,6 +58,11 @@
                     "description": "Target for link value URL (_blank, _self, _parent, _top, framename)",
                     "type": "string"
                 },
+                "limit": {
+                    "title": "Limit of field entity outputs",
+                    "description": "Used for aggregate fields, like file uploads",
+                    "type": "integer"
+                },
                 "translatable": {
                     "title": "Translatable button",
                     "description": "Allow Render translatable button",


### PR DESCRIPTION
Adding `limits` definition that's quite handy for aggregate fields that might link to multiple entities, like file uploads.