### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,22 +24,15 @@
             "php": "7.1"
         }
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
         "admad/cakephp-jwt-auth": "^2.0",
         "admad/cakephp-sequence": "^2.2",
         "alt3/cakephp-swagger": "^2.0",
         "arvenil/ninja-mutex": "^0.6",
-        "burzum/cakephp-file-storage": "dev-branch-2.0",
-        "burzum/cakephp-imagine-plugin": "dev-master#d21baf7378271d536982c8c0867fab3dcfa24cc8",
+        "burzum/cakephp-file-storage": "^2.0",
         "cakedc/users": "^8.0",
-        "cakephp/cakephp": "^3.5 <3.7",
-        "cakephp/migrations": "^1.7",
+        "cakephp/cakephp": "^3.6",
+        "cakephp/migrations": "^2.0",
         "friendsofcake/crud": "^5.4",
         "fzaninotto/faker": "^1.0",
         "josegonzalez/dotenv": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "burzum/cakephp-file-storage": "^2.0",
         "burzum/cakephp-imagine-plugin": "^2.0",
         "cakedc/users": "^8.0",
-        "cakephp/cakephp": "^3.6",
+        "cakephp/cakephp": "^3.8",
         "cakephp/migrations": "^2.0",
         "friendsofcake/crud": "^5.4",
         "fzaninotto/faker": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "alt3/cakephp-swagger": "^2.0",
         "arvenil/ninja-mutex": "^0.6",
         "burzum/cakephp-file-storage": "^2.0",
+        "burzum/cakephp-imagine-plugin": "^2.0",
         "cakedc/users": "^8.0",
         "cakephp/cakephp": "^3.6",
         "cakephp/migrations": "^2.0",


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.